### PR TITLE
Adding object documentation on object list page

### DIFF
--- a/app/src/app/views/stix/group/group-list/group-list.component.html
+++ b/app/src/app/views/stix/group/group-list/group-list.component.html
@@ -5,15 +5,13 @@
         </h1>
 
         <popover-content #PopoverTag 
-                popoverPlacement="bottom"
+                placement="bottom"
                 [animation]="true" 
                 [closeOnClickOutside]="true"
                  >
             <div class="popover-description">
                 <p>
                     Groups are sets of related intrusion activity that are tracked by a common name in the security community. Overlaps between names based on publicly reported associations are tracked using "Associated Groups" (also known as "Aliases").
-                    <br><br>
-                    Groups support the standard set of fields as well as the "Associated Groups" field. Each associated group is tracked using a name and description. The alias description is typically used to hold a set of citations, though plain-text can also be entered alongside citations if additional context is necessary. Alias names cannot be changed after they are added, but the description can be changed by clicking on the entry in the associated groups list.
                 </p>
             </div>
         </popover-content>

--- a/app/src/app/views/stix/group/group-list/group-list.component.html
+++ b/app/src/app/views/stix/group/group-list/group-list.component.html
@@ -1,6 +1,23 @@
 <div class="list-page">
     <div class="list-page-header">
-        <h1>groups</h1>
+        <h1 class="with-help-icon">
+            groups <mat-icon [popover]="PopoverTag" class="help-icon" aria-label="help">help_outline</mat-icon>
+        </h1>
+
+        <popover-content #PopoverTag 
+                popoverPlacement="bottom"
+                [animation]="true" 
+                [closeOnClickOutside]="true"
+                 >
+            <div class="popover-description">
+                <p>
+                    Groups are sets of related intrusion activity that are tracked by a common name in the security community. Overlaps between names based on publicly reported associations are tracked using "Associated Groups" (also known as "Aliases").
+                    <br><br>
+                    Groups support the standard set of fields as well as the "Associated Groups" field. Each associated group is tracked using a name and description. The alias description is typically used to hold a set of citations, though plain-text can also be entered alongside citations if additional context is necessary. Alias names cannot be changed after they are added, but the description can be changed by clicking on the entry in the associated groups list.
+                </p>
+            </div>
+        </popover-content>
+
         <div class="button-group">
             <button mat-mini-fab class="extended-fab-button" color="primary" [routerLink]="['/group/new']" [queryParams]="{editing: true}">
                 <mat-icon>create</mat-icon> <span class="text-label">create a group</span>

--- a/app/src/app/views/stix/group/group-list/group-list.component.ts
+++ b/app/src/app/views/stix/group/group-list/group-list.component.ts
@@ -6,7 +6,6 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./group-list.component.scss']
 })
 export class GroupListComponent implements OnInit {
-
     constructor() { }
 
     ngOnInit() {}

--- a/app/src/app/views/stix/matrix/matrix-list/matrix-list.component.html
+++ b/app/src/app/views/stix/matrix/matrix-list/matrix-list.component.html
@@ -1,6 +1,21 @@
 <div class="list-page">
     <div class="list-page-header">
-        <h1>matrices</h1>
+        <h1 class="with-help-icon">
+            matrices <mat-icon [popover]="PopoverTag" class="help-icon" aria-label="help">help_outline</mat-icon>
+        </h1>
+
+        <popover-content #PopoverTag 
+                popoverPlacement="bottom"
+                placement="bottom"
+                [animation]="true" 
+                [closeOnClickOutside]="true"
+                 >
+            <div class="popover-description">
+                <p>
+                    The relationship between tactics, techniques, and sub-techniques can be visualized in matrices   
+                </p>
+            </div>
+        </popover-content>
         <div class="button-group">
             <button mat-mini-fab class="extended-fab-button" color="primary" [routerLink]="['/matrix/new']" [queryParams]="{editing: true}">
                 <mat-icon>create</mat-icon> <span class="text-label">create a matrix</span>

--- a/app/src/app/views/stix/matrix/matrix-list/matrix-list.component.html
+++ b/app/src/app/views/stix/matrix/matrix-list/matrix-list.component.html
@@ -5,14 +5,13 @@
         </h1>
 
         <popover-content #PopoverTag 
-                popoverPlacement="bottom"
                 placement="bottom"
                 [animation]="true" 
                 [closeOnClickOutside]="true"
                  >
             <div class="popover-description">
                 <p>
-                    The relationship between tactics, techniques, and sub-techniques can be visualized in matrices   
+                    Matrices are an organized visualization depicting the relationships between tactics, techniques, and sub-techniques. ATT&CK Workbench does not support matrix visualizations at present, but you can still create and edit them for visualization in other tools.
                 </p>
             </div>
         </popover-content>

--- a/app/src/app/views/stix/mitigation/mitigation-list/mitigation-list.component.html
+++ b/app/src/app/views/stix/mitigation/mitigation-list/mitigation-list.component.html
@@ -1,6 +1,22 @@
 <div class="list-page">
     <div class="list-page-header">
-        <h1>mitigations</h1>
+        <h1 class="with-help-icon">
+            mitigations <mat-icon [popover]="PopoverTag" class="help-icon" aria-label="help">help_outline</mat-icon>
+        </h1>
+
+        <popover-content #PopoverTag 
+                popoverPlacement="bottom"
+                [animation]="true" 
+                [closeOnClickOutside]="true"
+                 >
+            <div class="popover-description">
+                <p>
+                    Mitigations represent security concepts and classes of technologies that can be used to prevent a technique or sub-technique from being successfully executed. They support the standard set of fields and must be assigned to a domain.
+                    <br><br>
+                    A special mitigation published within the Enterprise domain, "Do Not Mitigate," should be used to mark any techniques which should not be mitigated.
+                </p>
+            </div>
+        </popover-content>
         <div class="button-group">
             <button mat-mini-fab class="extended-fab-button" color="primary" [routerLink]="['/mitigation/new']" [queryParams]="{editing: true}">
                 <mat-icon>create</mat-icon> <span class="text-label">create a mitigation</span>

--- a/app/src/app/views/stix/mitigation/mitigation-list/mitigation-list.component.html
+++ b/app/src/app/views/stix/mitigation/mitigation-list/mitigation-list.component.html
@@ -5,15 +5,13 @@
         </h1>
 
         <popover-content #PopoverTag 
-                popoverPlacement="bottom"
+                placement="bottom"
                 [animation]="true" 
                 [closeOnClickOutside]="true"
                  >
             <div class="popover-description">
                 <p>
                     Mitigations represent security concepts and classes of technologies that can be used to prevent a technique or sub-technique from being successfully executed. They support the standard set of fields and must be assigned to a domain.
-                    <br><br>
-                    A special mitigation published within the Enterprise domain, "Do Not Mitigate," should be used to mark any techniques which should not be mitigated.
                 </p>
             </div>
         </popover-content>

--- a/app/src/app/views/stix/software/software-list/software-list.component.html
+++ b/app/src/app/views/stix/software/software-list/software-list.component.html
@@ -1,6 +1,32 @@
 <div class="list-page">
     <div class="list-page-header">
-        <h1>software</h1>
+        <h1 class="with-help-icon">
+            software <mat-icon [popover]="PopoverTag" class="help-icon" aria-label="help">help_outline</mat-icon>
+        </h1>
+
+        <popover-content #PopoverTag 
+                popoverPlacement="bottom"
+                [animation]="true" 
+                [closeOnClickOutside]="true"
+                 >
+            <div class="popover-description">
+                <p>
+                    Software is a generic term for custom or commercial code, operating system utilities, open-source software, or other tools used to conduct behavior modeled in ATT&CK. Some instances of software have multiple names associated with the same instance due to various organizations tracking the same set of software by different names. The team makes a best effort to track overlaps between names based on publicly reported associations, which are designated as “Associated Software” on each page (also known as "Aliases").
+                    <br><br>
+                    Software support the standard set of fields as well as the "Associated Software" field. Each associated software is tracked using a name and description. The alias description is typically used to hold a set of citations, though plain-text can also be entered alongside citations if additional context is necessary. Alias names cannot be changed after they are added, but the description can be changed by clicking on the entry in the associated groups list.
+                    <br><br>
+                    Types of Software:
+                </p>
+                <ul>
+                    <li>
+                        malware: commercial, custom closed source, or open source software intended to be used for malicious purposes by adversaries
+                    </li> 
+                    <li>
+                        tool: commercial, open-source, built-in, or publicly available software that could be used by a defender, pen tester, red teamer, or an adversary
+                    </li>
+                </ul>
+            </div>
+        </popover-content>
         <div class="button-group">
             <button mat-mini-fab class="extended-fab-button" color="primary" [routerLink]="['/software/new']" [queryParams]="{editing: true}">
                 <mat-icon>create</mat-icon> <span class="text-label">create a software</span>

--- a/app/src/app/views/stix/software/software-list/software-list.component.html
+++ b/app/src/app/views/stix/software/software-list/software-list.component.html
@@ -5,26 +5,14 @@
         </h1>
 
         <popover-content #PopoverTag 
-                popoverPlacement="bottom"
+                placement="bottom"
                 [animation]="true" 
                 [closeOnClickOutside]="true"
                  >
             <div class="popover-description">
                 <p>
                     Software is a generic term for custom or commercial code, operating system utilities, open-source software, or other tools used to conduct behavior modeled in ATT&CK. Some instances of software have multiple names associated with the same instance due to various organizations tracking the same set of software by different names. The team makes a best effort to track overlaps between names based on publicly reported associations, which are designated as “Associated Software” on each page (also known as "Aliases").
-                    <br><br>
-                    Software support the standard set of fields as well as the "Associated Software" field. Each associated software is tracked using a name and description. The alias description is typically used to hold a set of citations, though plain-text can also be entered alongside citations if additional context is necessary. Alias names cannot be changed after they are added, but the description can be changed by clicking on the entry in the associated groups list.
-                    <br><br>
-                    Types of Software:
                 </p>
-                <ul>
-                    <li>
-                        malware: commercial, custom closed source, or open source software intended to be used for malicious purposes by adversaries
-                    </li> 
-                    <li>
-                        tool: commercial, open-source, built-in, or publicly available software that could be used by a defender, pen tester, red teamer, or an adversary
-                    </li>
-                </ul>
             </div>
         </popover-content>
         <div class="button-group">

--- a/app/src/app/views/stix/tactic/tactic-list/tactic-list.component.html
+++ b/app/src/app/views/stix/tactic/tactic-list/tactic-list.component.html
@@ -1,6 +1,22 @@
 <div class="list-page">
     <div class="list-page-header">
-        <h1>tactics</h1>
+        <h1 class="with-help-icon">
+            tactics <mat-icon [popover]="PopoverTag" class="help-icon" aria-label="help">help_outline</mat-icon>
+        </h1>
+
+        <popover-content #PopoverTag 
+                popoverPlacement="bottom"
+                [animation]="true" 
+                [closeOnClickOutside]="true"
+                 >
+            <div class="popover-description">
+                <p>
+                    Tactics represent the "why" of an ATT&CK technique or sub-technique. It is the adversary's tactical goal: the reason for performing an action. For example, an adversary may want to achieve credential access.
+                    <br><br>
+                    Tactics support the standard set of fields, including a description supporting citations and markdown formatting. Tactics must be assigned to a domain before techniques can be assigned to them. The assignment of techniques to tactics can only be done on the techniques page.
+                </p>
+            </div>
+        </popover-content>
         <div class="button-group">
             <button mat-mini-fab class="extended-fab-button" color="primary" [routerLink]="['/tactic/new']" [queryParams]="{editing: true}">
                 <mat-icon>create</mat-icon> <span class="text-label">create a tactic</span>

--- a/app/src/app/views/stix/tactic/tactic-list/tactic-list.component.html
+++ b/app/src/app/views/stix/tactic/tactic-list/tactic-list.component.html
@@ -5,15 +5,13 @@
         </h1>
 
         <popover-content #PopoverTag 
-                popoverPlacement="bottom"
+                placement="bottom"
                 [animation]="true" 
                 [closeOnClickOutside]="true"
                  >
             <div class="popover-description">
                 <p>
                     Tactics represent the "why" of an ATT&CK technique or sub-technique. It is the adversary's tactical goal: the reason for performing an action. For example, an adversary may want to achieve credential access.
-                    <br><br>
-                    Tactics support the standard set of fields, including a description supporting citations and markdown formatting. Tactics must be assigned to a domain before techniques can be assigned to them. The assignment of techniques to tactics can only be done on the techniques page.
                 </p>
             </div>
         </popover-content>

--- a/app/src/app/views/stix/technique/technique-list/technique-list.component.html
+++ b/app/src/app/views/stix/technique/technique-list/technique-list.component.html
@@ -5,15 +5,13 @@
         </h1>
 
         <popover-content #PopoverTag 
-                popoverPlacement="bottom"
+                placement="bottom"
                 [animation]="true" 
                 [closeOnClickOutside]="true"
                  >
             <div class="popover-description">
                 <p>
                     Techniques represent "how" an adversary achieves a tactical goal by performing an action. For example, an adversary may dump credentials to achieve credential access.
-                    <br><br>
-                    Like all objects, techniques support descriptions with markdown and citation support. The detection field also supports markdown and citations. Additionally, techniques list relevant platforms according to their domain. After a domain has been selected, the user may select the relevant platforms from the dropdown menu.    
                 </p>
             </div>
         </popover-content>

--- a/app/src/app/views/stix/technique/technique-list/technique-list.component.html
+++ b/app/src/app/views/stix/technique/technique-list/technique-list.component.html
@@ -1,6 +1,22 @@
 <div class="list-page">
     <div class="list-page-header">
-        <h1>techniques</h1>
+        <h1 class="with-help-icon">
+            techniques <mat-icon [popover]="PopoverTag" class="help-icon" aria-label="help">help_outline</mat-icon>
+        </h1>
+
+        <popover-content #PopoverTag 
+                popoverPlacement="bottom"
+                [animation]="true" 
+                [closeOnClickOutside]="true"
+                 >
+            <div class="popover-description">
+                <p>
+                    Techniques represent "how" an adversary achieves a tactical goal by performing an action. For example, an adversary may dump credentials to achieve credential access.
+                    <br><br>
+                    Like all objects, techniques support descriptions with markdown and citation support. The detection field also supports markdown and citations. Additionally, techniques list relevant platforms according to their domain. After a domain has been selected, the user may select the relevant platforms from the dropdown menu.    
+                </p>
+            </div>
+        </popover-content>
         <div class="button-group">
             <button mat-mini-fab class="extended-fab-button" color="primary" [routerLink]="['/technique/new']" [queryParams]="{editing: true}">
                 <mat-icon>create</mat-icon> <span class="text-label">create a technique</span>

--- a/app/src/style/layouts/list-page.scss
+++ b/app/src/style/layouts/list-page.scss
@@ -5,6 +5,16 @@
             margin-top: 0;
             margin-bottom: 16px;
         }
+        h1.with-help-icon {
+            margin-left: 30px;
+        }
         margin-bottom: 16px;
+    }
+
+    .popover-description {
+        width: 30rem;
+        text-align: justify;
+        text-align-last: left;
+        padding: 0px 15px;
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,10 @@
 <!--    each repo's package.json file's version marking.                -->
 
 # Changelog
+### ATT&CK Workbench version 1.1.0
+#### Improvements in 1.1.0
+- Added object type documentation on list pages. See [frontend#221](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/issues/221).
+
 ## 21 June 2021
 ### ATT&CK Workbench version 1.0.0
 #### Improvements in 1.0.0


### PR DESCRIPTION
PR to add object documentation on object list pages.

Example:
<img width="1674" alt="Screen Shot 2021-09-14 at 2 55 03 PM" src="https://user-images.githubusercontent.com/12372037/133317317-f6b61b04-eae6-43f9-b58c-03970fab1b7f.png">


Closes #221 