### PR TITLE
Feature/#231

### DIFF
--- a/app/src/app/classes/stix/stix-object.ts
+++ b/app/src/app/classes/stix/stix-object.ts
@@ -322,31 +322,40 @@ export abstract class StixObject extends Serializable {
                             }
                         }
                         // check ATT&CK ID
-                        if (this.hasOwnProperty("attackID") && this.attackID != "") {
-                            if (objects.data.some(x => x.attackID == this.attackID && x.stixID != this.stixID)) {
-                                result.errors.push({
-                                    "result": "error",
+                        if (this.hasOwnProperty("attackID")) {
+                            if (this.attackID == "") {
+                                result.warnings.push({
+                                    "result": "warning",
                                     "field": "attackID",
-                                    "message": "ATT&CK ID is not unique"
-                                })
-                            } else {
-                                result.successes.push({
-                                    "result": "success",
-                                    "field": "attackID",
-                                    "message": "ATT&CK ID is unique"
+                                    "message": "Object does not have ATT&CK ID"
                                 })
                             }
-                            // (\S+--)? is an organization prefix, and should probably be improved when that is made an explicit feature
-                            let idRegex =  new RegExp("^(\\S+--)?" + this.attackIDValidator.regex + "$");
-                            let attackIDValid = idRegex.test(this.attackID);
-                            if (!attackIDValid) {
-                                result.errors.push({
-                                    "result": "error",
-                                    "field": "attackID",
-                                    "message": `ATT&CK ID does not match the format ${this.attackIDValidator.format}`
-                                })
+                            else {
+                                if (objects.data.some(x => x.attackID == this.attackID && x.stixID != this.stixID)) {
+                                    result.errors.push({
+                                        "result": "error",
+                                        "field": "attackID",
+                                        "message": "ATT&CK ID is not unique"
+                                    })
+                                } else {
+                                    result.successes.push({
+                                        "result": "success",
+                                        "field": "attackID",
+                                        "message": "ATT&CK ID is unique"
+                                    })
+                                }
+                                // (\S+--)? is an organization prefix, and should probably be improved when that is made an explicit feature
+                                let idRegex =  new RegExp("^(\\S+--)?" + this.attackIDValidator.regex + "$");
+                                let attackIDValid = idRegex.test(this.attackID);
+                                if (!attackIDValid) {
+                                    result.errors.push({
+                                        "result": "error",
+                                        "field": "attackID",
+                                        "message": `ATT&CK ID does not match the format ${this.attackIDValidator.format}`
+                                    })
+                                }
                             }
-                        }
+                        } 
                         return result;
                     })
                 )

--- a/app/src/app/classes/stix/stix-object.ts
+++ b/app/src/app/classes/stix/stix-object.ts
@@ -321,8 +321,8 @@ export abstract class StixObject extends Serializable {
                                 })
                             }
                         }
-                        // check ATT&CK ID
-                        if (this.hasOwnProperty("attackID")) {
+                        // check ATT&CK ID and ignore collections
+                        if (this.attackType != "collection" && this.hasOwnProperty("attackID")) {
                             if (this.attackID == "") {
                                 result.warnings.push({
                                     "result": "warning",

--- a/app/src/app/views/stix/collection/collection-view/collection-view.component.ts
+++ b/app/src/app/views/stix/collection/collection-view/collection-view.component.ts
@@ -20,7 +20,6 @@ import { StixViewPage } from '../../stix-view-page';
 import { environment } from "../../../../../environments/environment";
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { logger } from "../../../../util/logger";
-import { L } from '@angular/cdk/keycodes';
 
 type changeCategory = "additions" | "changes" | "minor_changes" | "revocations" | "deprecations";
 

--- a/app/src/app/views/stix/collection/collection-view/collection-view.component.ts
+++ b/app/src/app/views/stix/collection/collection-view/collection-view.component.ts
@@ -20,6 +20,7 @@ import { StixViewPage } from '../../stix-view-page';
 import { environment } from "../../../../../environments/environment";
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { logger } from "../../../../util/logger";
+import { L } from '@angular/cdk/keycodes';
 
 type changeCategory = "additions" | "changes" | "minor_changes" | "revocations" | "deprecations";
 
@@ -153,7 +154,14 @@ export class CollectionViewComponent extends StixViewPage implements OnInit {
 
                 //stage data for saving
                 this.stagedData = [];
+                let missingATTACKIDs = [];
                 for (let object of collectionStixIDToObject.values()) {
+                    // grab name of objects that do not have ATT&CK IDs
+                    if (object.hasOwnProperty("attackID")) {
+                        if (object.attackID == "" && object.hasOwnProperty("name")) {
+                            missingATTACKIDs.push(object["name"]);
+                        }
+                    }
                     // record associated identities/marking defs
                     if (object.created_by_ref) identities.add(object.created_by_ref);
                     if (object.modified_by_ref) identities.add(object.modified_by_ref);
@@ -248,6 +256,21 @@ export class CollectionViewComponent extends StixViewPage implements OnInit {
                     field: "contents",
                     message: `${relationship_stats.excluded_both} relationships had neither attached objects in the collection and were therefore excluded`
                 })
+                // Check for missing ATT&CK ids
+                if (missingATTACKIDs.length != 0) {
+                    let customMessage = "";
+                    if (missingATTACKIDs.length == 1) {
+                        customMessage = `1 object missing ATT&CK ID: ${missingATTACKIDs[0]}`
+                    }
+                    else {
+                        customMessage = `${missingATTACKIDs.length} objects missing ATT&CK IDs: ${missingATTACKIDs}`
+                    }
+                    results.warnings.push({
+                        result: "warning",
+                        field: "attackID",
+                        message: customMessage
+                    })
+                }
                 
                 //must have contents
                 if (this.stagedData.length == 0) results.errors.push({

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -2,6 +2,8 @@
 
 The ATT&CK Workbench is designed to integrate with a variety of tools. This page provides documentation on how to set up such integrations.
 
+It is a requirement for objects that support ATT&CK IDs to have one assigned. Integrations may not work as intended if ATT&CK IDs are not present from objects that support them such as techniques, tactics, and mitigations.
+
 ## ATT&CK Navigator
 
 The [ATT&CK Navigator](https://github.com/mitre-attack/attack-navigator) can be configured to display the contents of your local knowledge base. 


### PR DESCRIPTION
PR to add ATT&CK ID validation on pages that support ATT&CK IDs. Warnings will be displayed if ATT&CK IDs are not present. When creating and saving a collection, if an object that supports an ATT&CK ID does not have one but is included in the collection, the validation system will also warn and display the name of the objects that do not have ATT&CK IDs.

Updated the integration README to include ATT&CK ID requirements.

Closes #231 