### PR TITLE
Improve visibility of errors when importing collections

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "attack-workbench-frontend",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attack-workbench-frontend",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "An application allowing users to explore, create, annotate, and share extensions of the MITRE ATT&CK® knowledge base. This repository contains an Angular-based web application providing the user interface for the ATT&CK Workbench application.",
   "keywords": [
     "cti",

--- a/app/src/app/services/connectors/rest-api/rest-api-connector.service.ts
+++ b/app/src/app/services/connectors/rest-api/rest-api-connector.service.ts
@@ -1076,8 +1076,8 @@ export class RestApiConnectorService extends ApiConnector {
      * @param data: the data to download. Must be a JSON
      * @param filename: the name of the file to download
      */
-     private triggerBrowserDownload(data: any, filename: string) {
-        let url = URL.createObjectURL(new Blob([JSON.stringify(data)], {type: "text/json"}));
+     public triggerBrowserDownload(data: any, filename: string) {
+        let url = URL.createObjectURL(new Blob([JSON.stringify(data, null, 4)], {type: "text/json"}));
         let downloadLink = document.createElement("a");
         downloadLink.href = url;
         downloadLink.download = filename

--- a/app/src/app/views/stix/collection/collection-import/collection-import-workflow/collection-import.component.html
+++ b/app/src/app/views/stix/collection/collection-import/collection-import-workflow/collection-import.component.html
@@ -56,11 +56,27 @@
         </mat-step>
         <mat-step label="done">
             <div *ngIf="select">
-                <h3>Success!</h3>
+                <h3>Success! The collection has been imported into your workbench. </h3>
                 <p>
-                    The collection has been imported into your workbench. {{select.selected.length}} new objects were added. You can review the results of this import at any time on the <span class="text-label">imported collections</span> section of the collection page.
+                    {{successfully_saved.size}} new objects were added. You can review the imported objects at any time on the <span class="text-label">imported collections</span> section of the collection page.
                 </p>
-                <button mat-raised-button color="primary" routerLink="/collection">back to collections</button>
+                <ng-container *ngIf="save_errors.length > 0">
+                    <p>
+                        {{save_errors.length}} objects could not be imported. 
+                    </p>
+                    <mat-expansion-panel>
+                        <mat-expansion-panel-header>
+                            <mat-panel-title>
+                                Import errors
+                            </mat-panel-title>
+                        </mat-expansion-panel-header>
+                        <button mat-stroked-button (click)="downloadErrorLog()"><mat-icon>download</mat-icon> download this list</button>
+                        <code><pre class="error-log">{{save_errors | json}}</pre></code>
+                    </mat-expansion-panel>
+                </ng-container>
+                <p>
+                    <button mat-raised-button color="primary" routerLink="/collection">back to collections</button>
+                </p>
             </div>
         </mat-step>
     </mat-vertical-stepper>

--- a/app/src/app/views/stix/collection/collection-import/collection-import-workflow/collection-import.component.scss
+++ b/app/src/app/views/stix/collection/collection-import/collection-import-workflow/collection-import.component.scss
@@ -20,6 +20,11 @@
             flex-grow: 1;
         }
     }
+    .error-log {
+        overflow-x: scroll;
+        overflow-y: auto;
+        max-height: 30em;
+    }
 }
 // .collection-import {
 //     width: 45em;

--- a/app/src/app/views/stix/collection/collection-import/collection-import-workflow/collection-import.component.ts
+++ b/app/src/app/views/stix/collection/collection-import/collection-import-workflow/collection-import.component.ts
@@ -36,6 +36,8 @@ export class CollectionImportComponent implements OnInit {
     public changed_ids: string[] = [];
     // ids of objects which have nto changed (object-version not already in knowledge base)
     public unchanged_ids: string[] = [];
+    public save_errors: string[] = [];
+    public successfully_saved: Set<String> = new Set();
     public collectionBundle: any;
 
     public object_import_categories = {
@@ -215,7 +217,17 @@ export class CollectionImportComponent implements OnInit {
                         }
                         newBundle.objects = objects;
                         let subscription = this.restAPIConnectorService.postCollectionBundle(newBundle, false).subscribe({
-                            next: () => { 
+                            next: (results) => { 
+                                if (results.import_categories.errors.length > 0) {
+                                    logger.warn("Collection import completed with errors:", results.import_categories.errors);
+                                }
+                                this.save_errors = results.import_categories.errors.filter(err => err["error_type"] == "Save error");
+                                let save_error_ids = new Set(this.save_errors.map(err => err['object_ref']));
+                                for (let category in results.import_categories) {
+                                    if (category == "errors") continue;
+                                    for (let id of results.import_categories[category]) if (!save_error_ids.has(id)) this.successfully_saved.add(id);
+                                }
+                                logger.log("Successfully imported the following objects:", Array.from(this.successfully_saved));
                                 this.stepper.next(); 
                             },
                             complete: () => { subscription.unsubscribe(); } //prevent memory leaks
@@ -225,6 +237,13 @@ export class CollectionImportComponent implements OnInit {
             },
             complete: () => { promptSubscription.unsubscribe() } //prevent memory leaks
         })
+    }
+
+    /**
+     * Download a log of errors from the import
+     */
+    public downloadErrorLog() {
+        this.restAPIConnectorService.triggerBrowserDownload(this.save_errors, "import-errors.json")
     }
 
 }

--- a/app/src/app/views/stix/collection/collection-import/collection-import-workflow/collection-import.component.ts
+++ b/app/src/app/views/stix/collection/collection-import/collection-import-workflow/collection-import.component.ts
@@ -37,7 +37,7 @@ export class CollectionImportComponent implements OnInit {
     // ids of objects which have nto changed (object-version not already in knowledge base)
     public unchanged_ids: string[] = [];
     public save_errors: string[] = [];
-    public successfully_saved: Set<String> = new Set();
+    public successfully_saved: Set<string> = new Set();
     public collectionBundle: any;
 
     public object_import_categories = {

--- a/app/src/style/layouts/expansion-panel.scss
+++ b/app/src/style/layouts/expansion-panel.scss
@@ -5,7 +5,7 @@
         .dark & { border: 1px solid border-color(dark); }
         .light & { border: 1px solid border-color(light); }
     }
-    &:not(:first-child):not(.mat-expanded) { border-top-width: 0px }
+    &:not(:first-of-type):not(.mat-expanded) { border-top-width: 0px }
     &.mat-expanded + .mat-expansion-panel {
         border-top-width: 1px;
     }
@@ -13,7 +13,6 @@
         flex-basis: 0;
         align-items: center;
     }
-    .mat-expansion-panel-header-title { }
     .mat-expansion-panel-header-description {
         justify-content: flex-start;
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,13 +33,18 @@
 # Changelog
 
 ## Changes staged on develop
-### ATT&CK Workbench version 1.1.0
-#### Improvements in 1.1.0
+### ATT&CK Workbench version 1.0.3
+#### Improvements in 1.0.3
 - Added object type documentation on list pages. See [frontend#221](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/issues/221).
+- Improved the visibility of errors in collection imports:
+    - The user will now be provided with a downloadable list of objects that could not be saved (and the reason why) in the event of import errors.
+    - REST API will now log import errors to the console.
+    - Frontend will now log import errors to the console when the application environment is not set to production.
 
-#### Fixes in 1.1.0
+#### Fixes in 1.0.3
 - Fixed an issue where the navigation header could be inaccessible when navigating within the application or when the page resized due to user input.
-
+- Frontend will no longer claim objects were imported when they were actually discarded due to import errors such as spec violations.
+- Imported STIX bundles will no longer require (but still allow) the `spec_version` field on the bundle itself. This was causing issues importing collections created by the Workbench. Objects within the bundle still require the `spec_version` field per the STIX 2.1 spec. See [rest-api#103](https://github.com/center-for-threat-informed-defense/attack-workbench-rest-api/issues/103).
 ## 20 August 2021
 ### ATT&CK Workbench version 1.0.2
 #### Fixes in 1.0.2


### PR DESCRIPTION
- The user will now be provided with a downloadable list of objects that could not be saved (and the reason why) in the event of collection import errors.
- Frontend will now log import errors to the console when the application environment is not set to production.
- Frontend will no longer claim objects were imported when they were actually discarded due to import errors such as spec violations.
- Updated changelog for v1.0.3 release.
