### PR TITLE
v1.3.1 minor improvements

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "attack-workbench-frontend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attack-workbench-frontend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "An application allowing users to explore, create, annotate, and share extensions of the MITRE ATT&CK® knowledge base. This repository contains an Angular-based web application providing the user interface for the ATT&CK Workbench application.",
   "keywords": [
     "cti",

--- a/app/src/app/classes/stix/relationship.ts
+++ b/app/src/app/classes/stix/relationship.ts
@@ -114,7 +114,7 @@ export class Relationship extends StixObject {
         let serialized = this.serialize();
         let modified = new_source_object.modified;
         serialized.source_object = new_source_object.serialize();
-        serialized.source_object["stix"].modified = modified; // fix modified date overwrite by serialization
+        serialized.source_object["stix"].modified = modified.toISOString(); // fix modified date overwrite by serialization
         this.deserialize(serialized);
 
         if (this.source_object.stix.x_mitre_is_subtechnique || this.source_object.stix.type == 'x-mitre-data-component') {
@@ -178,7 +178,7 @@ export class Relationship extends StixObject {
         let serialized = this.serialize();
         let modified = new_target_object.modified;
         serialized.target_object = new_target_object.serialize();
-        serialized.target_object["stix"].modified = modified; // fix modified date overwrite by serialization
+        serialized.target_object["stix"].modified = modified.toISOString(); // fix modified date overwrite by serialization
         this.deserialize(serialized);
 
         if (this.target_object.stix.x_mitre_is_subtechnique || this.target_object.stix.type == 'x-mitre-data-component') {

--- a/app/src/app/classes/stix/relationship.ts
+++ b/app/src/app/classes/stix/relationship.ts
@@ -112,7 +112,9 @@ export class Relationship extends StixObject {
         this.updating_refs = true;
         this.source_ref = new_source_object.stixID;
         let serialized = this.serialize();
+        let modified = new_source_object.modified;
         serialized.source_object = new_source_object.serialize();
+        serialized.source_object["stix"].modified = modified; // fix modified date overwrite by serialization
         this.deserialize(serialized);
 
         if (this.source_object.stix.x_mitre_is_subtechnique || this.source_object.stix.type == 'x-mitre-data-component') {
@@ -174,7 +176,9 @@ export class Relationship extends StixObject {
         this.updating_refs = true;
         this.target_ref = new_target_object.stixID;
         let serialized = this.serialize();
+        let modified = new_target_object.modified;
         serialized.target_object = new_target_object.serialize();
+        serialized.target_object["stix"].modified = modified; // fix modified date overwrite by serialization
         this.deserialize(serialized);
 
         if (this.target_object.stix.x_mitre_is_subtechnique || this.target_object.stix.type == 'x-mitre-data-component') {

--- a/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.ts
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.ts
@@ -32,6 +32,7 @@ export class ReferenceEditDialogComponent implements OnInit {
             this.is_new = true;
             this.citation.day = new FormControl(null, [Validators.max(31), Validators.min(1)]);
             this.citation.year = new FormControl(null, [Validators.max(2100), Validators.min(1970)]);
+            this.citation.retrieved = new Date(); // default to current date
             this.reference = {
                 source_name: "",
                 url: "",

--- a/app/src/app/components/stix/descriptive-property/descriptive-property.component.ts
+++ b/app/src/app/components/stix/descriptive-property/descriptive-property.component.ts
@@ -3,41 +3,41 @@ import { StixObject } from 'src/app/classes/stix/stix-object';
 import { ExternalReferences } from 'src/app/classes/external-references';
 
 @Component({
-  selector: 'app-descriptive-property',
-  templateUrl: './descriptive-property.component.html',
-  styleUrls: ['./descriptive-property.component.scss']
+    selector: 'app-descriptive-property',
+    templateUrl: './descriptive-property.component.html',
+    styleUrls: ['./descriptive-property.component.scss']
 })
 export class DescriptivePropertyComponent implements OnInit {
-  @Input() public config: DescriptivePropertyConfig;
+    @Input() public config: DescriptivePropertyConfig;
 
-  constructor() { }
+    constructor() { }
 
-  ngOnInit(): void {
-  }
+    ngOnInit(): void {
+    }
 
 }
 
 export interface DescriptivePropertyConfig {
-  /* What is the current mode? Default: 'view
-   *    view: viewing the descriptive property
-   *    edit: editing the descriptive property
-   *    diff: displaying the diff between two STIX objects. If this mode is selected, two StixObjects must be specified in the objects field
-   */
-  mode?: "view" | "edit" | "diff";
-  /* The object to show the descriptive field of
-   * Note: if mode is diff, pass an array of two objects to diff
-   */
-  object: StixObject | [StixObject, StixObject];
-  /** field; field of object to be displayed */
-  field: string;
-  /** firstParagraphOnly; force descriptive field to show first paragragh only */
-  firstParagraphOnly?: boolean;
-  /* referencesField; external references object. 
-   * References will be removed if not included 
-   */
-  referencesField?: ExternalReferences;
-  /* label; label for labelled box
-   * Required when using view mode
-   */
-  label?: string;
+    /* What is the current mode? Default: 'view
+     *    view: viewing the descriptive property
+     *    edit: editing the descriptive property
+     *    diff: displaying the diff between two STIX objects. If this mode is selected, two StixObjects must be specified in the objects field
+     */
+    mode?: "view" | "edit" | "diff";
+    /* The object to show the descriptive field of
+     * Note: if mode is diff, pass an array of two objects to diff
+     */
+    object: StixObject | [StixObject, StixObject];
+    /** field; field of object to be displayed */
+    field: string;
+    /** firstParagraphOnly; force descriptive field to show first paragragh only */
+    firstParagraphOnly?: boolean;
+    /* referencesField; external references object. 
+     * References will be removed if not included 
+     */
+    referencesField?: ExternalReferences;
+    /* label; label for labelled box
+     * Required when using view mode
+     */
+    label?: string;
 }

--- a/app/src/app/components/stix/external-references-property/external-references-view/external-references-view.component.html
+++ b/app/src/app/components/stix/external-references-property/external-references-view/external-references-view.component.html
@@ -1,19 +1,17 @@
-<div class="external-references-view" *ngIf="display.length > 0">
+<div class="external-references-view" *ngIf="referenceList.length > 0 else loading">
     <div class="row">
         <div class="col">
-            <ol [class.twocol]="display.length > 1">
-                <li *ngFor="let ref of display; index as i" value="{{i+1}}" [ngClass]="{'external-link': ref[1].url}" >
+            <ol [class.twocol]="referenceList.length > 1">
+                <li *ngFor="let ref of referenceList" value="{{ref[0]}}" [ngClass]="{'external-link': ref[1].url}">
                     <span>
-                        <a *ngIf="ref[1].url && ref[1].description"class="external-link" rel="nofollow" href="{{ref[1].url}}" target="_blank">
-                            {{ref[1].description}}
-                        </a>
-                        <div *ngIf="!ref[1].url && ref[1].description">
-                            {{ref[1].description}}
-                        </div>
+                    <a *ngIf="ref[1].url && ref[1].description" class="external-link" rel="nofollow" [href]="ref[1].url" target="_blank">{{ref[1].description}}</a>
+                    <div *ngIf="!ref[1].url && ref[1].description">{{ref[1].description}}</div>
                     </span>
                 </li>
             </ol>
         </div>
     </div>
 </div>
-
+<ng-template #loading>
+    <app-loading-overlay></app-loading-overlay>
+</ng-template>

--- a/app/src/app/components/stix/external-references-property/external-references-view/external-references-view.component.ts
+++ b/app/src/app/components/stix/external-references-property/external-references-view/external-references-view.component.ts
@@ -1,27 +1,20 @@
 import { Component, OnInit, Input, ViewEncapsulation } from '@angular/core';
-import { ExternalReferencesPropertyConfig } from '../external-references-property.component';
 import { ExternalReference } from 'src/app/classes/external-references';
+import { ExternalReferencesPropertyConfig } from '../external-references-property.component';
 
 @Component({
-  selector: 'app-external-references-view',
-  templateUrl: './external-references-view.component.html',
-  styleUrls: ['./external-references-view.component.scss'],
-  encapsulation: ViewEncapsulation.None
+    selector: 'app-external-references-view',
+    templateUrl: './external-references-view.component.html',
+    styleUrls: ['./external-references-view.component.scss'],
+    encapsulation: ViewEncapsulation.None
 })
 export class ExternalReferencesViewComponent implements OnInit {
-  @Input() public config: ExternalReferencesPropertyConfig;
-  
-  constructor() { }
+    @Input() public config: ExternalReferencesPropertyConfig;
+    public referenceList: Array<[number, ExternalReference]> = [];
 
-  ngOnInit(): void {
-  }
+    constructor() { }
 
-  /**
-   * get list of references that will appear on the external references
-   * section
-   */
-  public get display(): Array<[number, ExternalReference]> {
-    return this.config.referencesField.list();
-  }
-
+    ngOnInit(): void {
+        this.referenceList = this.config.referencesField.list();
+    }
 }

--- a/app/src/app/components/stix/external-references-property/external-references-view/external-references-view.component.ts
+++ b/app/src/app/components/stix/external-references-property/external-references-view/external-references-view.component.ts
@@ -1,5 +1,7 @@
-import { Component, OnInit, Input, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, Input, ViewEncapsulation, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { ExternalReference } from 'src/app/classes/external-references';
+import { EditorService } from 'src/app/services/editor/editor.service';
 import { ExternalReferencesPropertyConfig } from '../external-references-property.component';
 
 @Component({
@@ -8,13 +10,26 @@ import { ExternalReferencesPropertyConfig } from '../external-references-propert
     styleUrls: ['./external-references-view.component.scss'],
     encapsulation: ViewEncapsulation.None
 })
-export class ExternalReferencesViewComponent implements OnInit {
+export class ExternalReferencesViewComponent implements OnInit, OnDestroy {
     @Input() public config: ExternalReferencesPropertyConfig;
+    public onEditStopSubscription: Subscription;
     public referenceList: Array<[number, ExternalReference]> = [];
 
-    constructor() { }
+    constructor(private editorService: EditorService) {
+        this.onEditStopSubscription = this.editorService.onEditingStopped.subscribe({
+            next: () => { this.loadReferences(); } // reload references when done editing
+        })
+    }
 
     ngOnInit(): void {
+        this.loadReferences();
+    }
+
+    ngOnDestroy(): void {
+        this.onEditStopSubscription.unsubscribe();
+    }
+
+    public loadReferences(): void {
         this.referenceList = this.config.referencesField.list();
     }
 }

--- a/app/src/app/components/stix/name-property/name-property.component.html
+++ b/app/src/app/components/stix/name-property/name-property.component.html
@@ -1,6 +1,7 @@
 <h1 class="name-property">
     <ng-container *ngIf="config.mode == 'view'; else edit">
-        <span *ngIf="config.parent">{{config.parent.name}}: </span> {{config.object[config.field ? config.field : "name"]}}
+        <span *ngIf="config.parent">
+            <a class="external-link" [href]="internalParentLink" target="_blank">{{config.parent.name}}</a>: </span> {{config.object[config.field ? config.field : "name"]}}
         <app-icon-view [config]="{object: config.object, field: 'workflow'}"></app-icon-view>
     </ng-container>
     <ng-template #edit>

--- a/app/src/app/components/stix/name-property/name-property.component.ts
+++ b/app/src/app/components/stix/name-property/name-property.component.ts
@@ -33,6 +33,12 @@ export class NamePropertyComponent implements OnInit {
         }
     }
 
+    /**
+     * retrieve the internal link to the parent technique
+     */
+    public get internalParentLink(): string {
+        return `/${this.config.parent.attackType}/${this.config.parent.stixID}`;
+    }
 }
 
 export interface NamePropertyConfig {

--- a/app/src/app/views/stix/relationship/relationship-view/relationship-view.component.html
+++ b/app/src/app/views/stix/relationship/relationship-view/relationship-view.component.html
@@ -40,7 +40,11 @@
                 <mat-expansion-panel [expanded]="relationship.target_object && !relationship.source_object" class="mat-elevation-z0">
                     <mat-expansion-panel-header>
                         <mat-panel-title>
-                            {{!relationship.source_object? 'select a source object' : relationship.source_name}}
+                            <span *ngIf="!relationship.source_object">select a source object</span>
+                            <span *ngIf="relationship.source_object">
+                                {{relationship.source_name}}
+                                <span class="text-deemphasis">{{getObjectDetails(relationship.source_object)}}</span>
+                            </span>
                         </mat-panel-title>
                         <ng-template matExpansionPanelContent>
                             <mat-form-field appearance="outline" class="type_select">
@@ -59,7 +63,11 @@
                 <mat-expansion-panel [expanded]="relationship.source_object && !relationship.target_object" class="mat-elevation-z0">
                     <mat-expansion-panel-header>
                         <mat-panel-title>
-                            {{!relationship.target_object? 'select a target object' : relationship.target_name}}
+                            <span *ngIf="!relationship.target_object">select a target object</span>
+                            <span *ngIf="relationship.target_object">
+                                {{relationship.target_name}}
+                                <span class="text-deemphasis">{{getObjectDetails(relationship.target_object)}}</span>
+                            </span>
                         </mat-panel-title>
                         <ng-template matExpansionPanelContent>
                             <mat-form-field appearance="outline" class="type_select">

--- a/app/src/app/views/stix/relationship/relationship-view/relationship-view.component.ts
+++ b/app/src/app/views/stix/relationship/relationship-view/relationship-view.component.ts
@@ -5,6 +5,7 @@ import { StixObject, stixTypeToAttackType } from 'src/app/classes/stix/stix-obje
 import { AuthenticationService } from 'src/app/services/connectors/authentication/authentication.service';
 import { RestApiConnectorService } from 'src/app/services/connectors/rest-api/rest-api-connector.service';
 import { StixViewPage } from '../../stix-view-page';
+import * as moment from 'moment';
 
 @Component({
   selector: 'app-relationship-view',
@@ -48,7 +49,7 @@ export class RelationshipViewComponent extends StixViewPage implements OnInit {
             }
         }
         if (this.relationship.target_object) {
-            if ( (this.relationship.target_object.stix.x_mitre_is_subtechnique || this.target_type == 'data-component') ) {
+            if (this.relationship.target_object.stix.x_mitre_is_subtechnique || this.target_type == 'data-component') {
                 parent_calls.push(this.relationship.update_target_parent(this.restApiService));
             }
         }
@@ -74,4 +75,20 @@ export class RelationshipViewComponent extends StixViewPage implements OnInit {
         }) 
     }
 
+    /**
+     * Get the object version and last modified date information to display in the relationship view
+     * @param {any} obj the object to retrieve details for
+     * @returns formatted string with object's version (if defined) and last modified date (if defined)
+     */
+    public getObjectDetails(obj: any): string {
+        if (!obj || !obj["stix"]) return '';
+
+        let version = obj["stix"].x_mitre_version;
+        let modified = obj["stix"].modified ? moment(obj["stix"].modified).format('D MMM YYYY, h:mm A') : undefined;
+        
+        if (version && modified) return `(v${version}, last modified ${modified})`;
+        else if (version && !modified) return `(v${version})`;
+        else if (!version && modified) return `(last modified ${modified})`;
+        else return '';
+    }
 }

--- a/app/src/app/views/stix/software/software-view/software-view.component.html
+++ b/app/src/app/views/stix/software/software-view/software-view.component.html
@@ -26,6 +26,17 @@
     </div>
     <div class="row">
         <div class="col">
+            <!-- DOMAINS-->
+            <app-list-property class="grow-to-row" [config]="{
+                mode: editing? 'edit': 'view',
+                object: software,
+                field: 'domains',
+                editType: 'select'
+            }"></app-list-property>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col">
             <!-- TYPE -->
             <div class="labelled-box grow-to-row" matTooltip="this field cannot be edited" [matTooltipDisabled]="!editing">
                 <div class="content capitalize">
@@ -76,16 +87,6 @@
                 referencesField: software.external_references,
                 label: 'Description'
             }"></app-descriptive-property>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col">
-            <app-list-property class="grow-to-row" [config]="{
-                mode: editing? 'edit': 'view',
-                object: software,
-                field: 'domains',
-                editType: 'select'
-            }"></app-list-property>
         </div>
     </div>
     <!-- only show relationships if configured to show them -->

--- a/app/src/app/views/stix/technique/technique-view/technique-view.component.html
+++ b/app/src/app/views/stix/technique/technique-view/technique-view.component.html
@@ -18,7 +18,7 @@
                 object: technique
             }"></app-attackid-property>
         </div>
-        <div class="col subtechnique-box">
+        <div class="col" [ngClass]="{'no-padding': editing}">
             <div class="labelled-box grow-to-row">
                 <!-- TYPE -->
                 <div class="content no-label">

--- a/app/src/app/views/stix/technique/technique-view/technique-view.component.html
+++ b/app/src/app/views/stix/technique/technique-view/technique-view.component.html
@@ -18,16 +18,7 @@
                 object: technique
             }"></app-attackid-property>
         </div>
-        <div class="col">
-            <!-- VERSION NUMBER -->
-            <app-version-property class="grow-to-row" [config]="{
-                mode: editing? 'edit' : 'view',
-                object: technique
-            }"></app-version-property>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col">
+        <div class="col subtechnique-box">
             <div class="labelled-box grow-to-row">
                 <!-- TYPE -->
                 <div class="content no-label">
@@ -38,49 +29,11 @@
             </div>
         </div>
         <div class="col">
-            <!-- PLATFORMS -->
-            <app-list-property class="grow-to-row" [config]="{
-                mode: editing? 'edit': 'view',
-                object: technique,
-                field: 'platforms',
-                editType: 'select'
-            }"></app-list-property>
-        </div>
-    </div>
-    <!-- ADDITIONAL IDs -->
-    <div *ngIf="technique.capec_ids.length || (editing && technique.domains.includes('enterprise-attack'))" class="row">
-        <div class="col">
-            <app-list-property class="grow-to-row" [config]="{
-                mode: editing? 'edit': 'view',
-                object: technique,
-                field: 'capec_ids',
-                label: 'CAPEC IDs',
-                editType: 'any'
-            }"></app-list-property>
-        </div>
-    </div>
-    <div *ngIf="technique.mtc_ids.length || (editing && technique.domains.includes('mobile-attack'))" class="row">
-        <div class="col">
-            <app-list-property class="grow-to-row" [config]="{
-                mode: editing? 'edit': 'view',
-                object: technique,
-                field: 'mtc_ids',
-                label: 'MTC IDs',
-                editType: 'any'
-            }"></app-list-property>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col">
-            <!-- DESCRIPTION -->
-            <app-descriptive-property [config]="{
+            <!-- VERSION NUMBER -->
+            <app-version-property class="grow-to-row" [config]="{
                 mode: editing? 'edit' : 'view',
-                object: technique,
-                field: 'description',
-                firstParagraphOnly: false, 
-                referencesField: technique.external_references,
-                label: 'Description'
-            }"></app-descriptive-property>
+                object: technique
+            }"></app-version-property>
         </div>
     </div>
     <!-- DOMAIN SPECIFIC FIELDS -->
@@ -133,6 +86,53 @@
                 </div>
             </div>
         </ng-container>
+    </div>
+    <div class="row">
+        <div class="col">
+            <!-- PLATFORMS -->
+            <app-list-property class="grow-to-row" [config]="{
+                mode: editing? 'edit': 'view',
+                object: technique,
+                field: 'platforms',
+                editType: 'select'
+            }"></app-list-property>
+        </div>
+    </div>
+    <!-- ADDITIONAL IDs -->
+    <div *ngIf="technique.capec_ids.length || (editing && technique.domains.includes('enterprise-attack'))" class="row">
+        <div class="col">
+            <app-list-property class="grow-to-row" [config]="{
+                mode: editing? 'edit': 'view',
+                object: technique,
+                field: 'capec_ids',
+                label: 'CAPEC IDs',
+                editType: 'any'
+            }"></app-list-property>
+        </div>
+    </div>
+    <div *ngIf="technique.mtc_ids.length || (editing && technique.domains.includes('mobile-attack'))" class="row">
+        <div class="col">
+            <app-list-property class="grow-to-row" [config]="{
+                mode: editing? 'edit': 'view',
+                object: technique,
+                field: 'mtc_ids',
+                label: 'MTC IDs',
+                editType: 'any'
+            }"></app-list-property>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col">
+            <!-- DESCRIPTION -->
+            <app-descriptive-property [config]="{
+                mode: editing? 'edit' : 'view',
+                object: technique,
+                field: 'description',
+                firstParagraphOnly: false, 
+                referencesField: technique.external_references,
+                label: 'Description'
+            }"></app-descriptive-property>
+        </div>
     </div>
     <!-- TACTIC SPECIFIC FIELDS -->
     <div *ngIf="technique.tactics.length > 0 || editing" class="row">

--- a/app/src/app/views/stix/technique/technique-view/technique-view.component.scss
+++ b/app/src/app/views/stix/technique/technique-view/technique-view.component.scss
@@ -5,4 +5,13 @@
         align-items: center;
         justify-content: center;
     }
+
+    .mat-form-field-wrapper {
+        margin: 0;
+        padding: 0;
+    }
+
+    .subtechnique-box {
+        .labelled-box { padding-top: 0px; }
+    }
 }

--- a/app/src/app/views/stix/technique/technique-view/technique-view.component.scss
+++ b/app/src/app/views/stix/technique/technique-view/technique-view.component.scss
@@ -11,7 +11,7 @@
         padding: 0;
     }
 
-    .subtechnique-box {
+    .no-padding {
         .labelled-box { padding-top: 0px; }
     }
 }


### PR DESCRIPTION
Summary of changes:
- Fixes broken external reference links at the bottom of object pages. Resolves #306 
- Adds a link to the parent technique page from the sub-technique page. Resolves #309 
- Adds a default `retrieved` date to new references. Resolves #305 
- Rearrange fields on object pages to better follow selection order. Resolves #302 
- Show the source and target objects' versions and last modified date in the relationship dialog. Resolves #313 