### PR TITLE
Reference View

### DIFF
--- a/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.html
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.html
@@ -124,7 +124,7 @@
             </ng-container>
         </ng-template>
         <div class="buttons">
-            <button mat-button matDialogClose>cancel</button>
+            <button mat-button (click)="stage=0">cancel</button>
             <button mat-stroked-button *ngIf="patch_objects.length > 0 || patch_relationships > 0" (click)="patch()">apply patches and save</button>
             <button mat-stroked-button *ngIf="patch_objects.length == 0 && patch_relationships == 0" (click)="save()">save</button>
         </div>
@@ -161,7 +161,7 @@
                 </div>
             </div>
         </div>
-        <div class="row">
+        <div class="row" *ngIf="reference.url">
             <div class="col">
                 <div class="labelled-box grow-to-row">
                     <div class="content">
@@ -173,7 +173,7 @@
         </div>
         <div class="buttons">
             <button mat-button matDialogClose>close</button>
-            <button mat-stroked-button (click)="config.mode = 'edit'">edit</button>
+            <button mat-stroked-button (click)="toggle('edit')">edit</button>
         </div>
     </div>
 </ng-template>

--- a/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.html
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.html
@@ -1,7 +1,6 @@
-<div class="reference-edit-dialog">
+<div *ngIf="config.mode == 'edit' || !config.mode else viewReference" class="reference-edit-dialog">
     <div *ngIf="stage == 0" class="stage edit">
         <h1>Reference Editor</h1>
-
         <div class="grid spacing-16">
             <div class="row">
                 <div class="column editor">
@@ -135,3 +134,46 @@
         <app-loading-overlay></app-loading-overlay>
     </div>
 </div>
+
+<ng-template #viewReference>
+    <div class="reference-view-dialog grid spacing-12">
+        <h1>{{reference.source_name}}</h1>
+        <div class="row">
+            <div class="col">
+                <div class="labelled-box grow-to-row">
+                    <div class="content">
+                        (Citation: {{reference.source_name}})
+                    </div>
+                    <label>In-text citation</label>
+                </div>
+            </div>
+            <div class="col narrow rel-button clickable" [cdkCopyToClipboard]="citationTag" (click)="snackbar.open('Citation copied to clipboard', null, {duration: 500})">
+                <mat-icon aria-label="copy">content_copy</mat-icon>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col">
+                <div class="labelled-box grow-to-row">
+                    <div class="content">
+                        <span>{{reference.description}}</span>
+                    </div>
+                    <label>Full reference text</label>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col">
+                <div class="labelled-box grow-to-row">
+                    <div class="content">
+                        <span>{{reference.url}}</span>
+                    </div>
+                    <label>URL</label>
+                </div>
+            </div>
+        </div>
+        <div class="buttons">
+            <button mat-button matDialogClose>close</button>
+            <button mat-stroked-button (click)="config.mode = 'edit'">edit</button>
+        </div>
+    </div>
+</ng-template>

--- a/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.html
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="config.mode == 'edit' || !config.mode else viewReference" class="reference-edit-dialog">
+<div *ngIf="config.mode == 'edit' else viewReference" class="reference-edit-dialog">
     <div *ngIf="stage == 0" class="stage edit">
         <h1>Reference Editor</h1>
         <div class="grid spacing-16">

--- a/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.html
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.html
@@ -85,7 +85,7 @@
             </div>
         </div>
         <div class="buttons">
-            <button mat-button matDialogClose>cancel</button>
+            <button mat-button (click)="is_new ? dialogRef.close() : toggle('view')">cancel</button>
             <button mat-stroked-button [disabled]="!reference.source_name || (!is_new && !reference.description) || (is_new && (!citation.authors || !citation.retrieved || !validDate()))" (click)="next()">
                 {{is_new ? 'save' : 'next'}}
             </button>

--- a/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.scss
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.scss
@@ -26,6 +26,7 @@
     }
 }
 .reference-view-dialog {
+    max-width: 50vw;
     .rel-button {
         justify-content: center;
     }

--- a/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.scss
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.scss
@@ -27,6 +27,7 @@
 }
 .reference-view-dialog {
     max-width: 50vw;
+    min-width: 35vw;
     .rel-button {
         justify-content: center;
     }

--- a/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.scss
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.scss
@@ -11,13 +11,6 @@
     .stage.edit .mat-form-field {
         width: 100%;
     }
-    .buttons {
-        button + button {
-            margin-left: 10px;
-        }
-        margin-top: 24px;
-        margin-bottom: 24px;
-    }
     .grid {
         .editor {
             max-width: 66% !important;
@@ -31,4 +24,23 @@
         }
         .editor .mat-form-field-infix { width: unset; }
     }
+}
+.reference-view-dialog {
+    .rel-button {
+        justify-content: center;
+    }
+    .clickable {
+        cursor: pointer;
+        &:hover { 
+            .dark & { background: color-alternate(dark); }
+            .light & { background: color-alternate(light); }
+        }
+    }
+}
+.buttons {
+    button + button {
+        margin-left: 10px;
+    }
+    margin-top: 24px;
+    margin-bottom: 24px;
 }

--- a/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.ts
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject, OnInit, ViewEncapsulation } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { forkJoin } from 'rxjs';
 import { ExternalReference } from 'src/app/classes/external-references';
 import { Relationship } from 'src/app/classes/stix/relationship';
@@ -25,7 +26,7 @@ export class ReferenceEditDialogComponent implements OnInit {
 
     public get citationTag(): string { return `(Citation: ${this.reference.source_name})`; }
 
-    constructor(public dialogRef: MatDialogRef<ReferenceEditDialogComponent>, @Inject(MAT_DIALOG_DATA) public config: ReferenceEditConfig, public restApiConnectorService: RestApiConnectorService) {
+    constructor(public dialogRef: MatDialogRef<ReferenceEditDialogComponent>, @Inject(MAT_DIALOG_DATA) public config: ReferenceEditConfig, public restApiConnectorService: RestApiConnectorService, public snackbar: MatSnackBar) {
         if (this.config.reference) {
             this.is_new = false;
             this.reference = JSON.parse(JSON.stringify(this.config.reference)); //deep copy

--- a/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.ts
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.ts
@@ -137,7 +137,10 @@ export class ReferenceEditDialogComponent implements OnInit {
         }
         this.stage = 3;
         let subscription = forkJoin(saves).subscribe({
-            complete: () => { subscription.unsubscribe(); this.dialogRef.close(); }
+            complete: () => {
+                this.toggle('view');
+                subscription.unsubscribe();
+            }
         })
     }
 
@@ -147,13 +150,21 @@ export class ReferenceEditDialogComponent implements OnInit {
     public save() {
         let api = this.is_new? this.restApiConnectorService.postReference(this.reference) : this.restApiConnectorService.putReference(this.reference);
         let subscription = api.subscribe({
-            complete: () => { 
+            complete: () => {
+                this.is_new = false;
+                this.toggle('view');
                 subscription.unsubscribe();
-                this.dialogRef.close();
             }
         });
     }
 
+    /**
+     * change the current mode
+     * @param mode 'view' or 'edit'
+     */
+    public toggle(mode: 'view' | 'edit') {
+        this.config.mode = mode;
+    }
 }
 
 export interface ReferenceEditConfig {

--- a/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.ts
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-edit-dialog/reference-edit-dialog.component.ts
@@ -23,6 +23,8 @@ export class ReferenceEditDialogComponent implements OnInit {
     public months: string[] = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
     public citation: any = {};
 
+    public get citationTag(): string { return `(Citation: ${this.reference.source_name})`; }
+
     constructor(public dialogRef: MatDialogRef<ReferenceEditDialogComponent>, @Inject(MAT_DIALOG_DATA) public config: ReferenceEditConfig, public restApiConnectorService: RestApiConnectorService) {
         if (this.config.reference) {
             this.is_new = false;
@@ -155,5 +157,10 @@ export class ReferenceEditDialogComponent implements OnInit {
 }
 
 export interface ReferenceEditConfig {
+    /* What is the current mode? Default: 'view'
+    *    view: viewing the reference
+    *    edit: editing the reference
+    */
+    mode?: "view" | "edit";
     reference?: ExternalReference
 }

--- a/app/src/app/components/resources-drawer/reference-manager/reference-manager.component.html
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-manager.component.html
@@ -1,6 +1,6 @@
 <div class="references-manager">
     <div class="add-container" *ngIf="editable && canEdit">
-        <button mat-mini-fab class="extended-fab-button" color="primary" (click)="editReference()">
+        <button mat-mini-fab class="extended-fab-button" color="primary" (click)="openReference(true)">
             <mat-icon>add</mat-icon> <span class="text-label">add a reference</span>
         </button>
     </div>
@@ -24,11 +24,8 @@
                         </div>
                         <div class="text-label lowercase">{{reference.source_name}}</div>
                     </div>
-                    <div class="col narrow clickable" (click)="viewReference(reference)">
-                        <mat-icon aria-label="view">visibility</mat-icon>
-                    </div>
-                    <div class="col narrow clickable" *ngIf="editable && canEdit" (click)="editReference(reference)">
-                        <mat-icon aria-label="edit">edit</mat-icon>
+                    <div class="col narrow clickable" (click)="openReference(false, reference)">
+                        <mat-icon aria-label="open">open_in_new</mat-icon>
                     </div>
                 </div>
             </div>

--- a/app/src/app/components/resources-drawer/reference-manager/reference-manager.component.html
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-manager.component.html
@@ -15,7 +15,7 @@
             <div class="reference-list grid">
                 <div class="reference row" *ngFor="let reference of references.data">
                     <div class="col narrow clickable" [cdkCopyToClipboard]="getCitation(reference.source_name)" (click)="snackbar.open('Citation copied to clipboard', null, {duration: 500})">
-                        <mat-icon>content_copy</mat-icon>
+                        <mat-icon aria-label="copy">content_copy</mat-icon>
                     </div>
                     <div class="col">
                         <div class="description">
@@ -24,8 +24,11 @@
                         </div>
                         <div class="text-label lowercase">{{reference.source_name}}</div>
                     </div>
+                    <div class="col narrow clickable" (click)="viewReference(reference)">
+                        <mat-icon aria-label="view">visibility</mat-icon>
+                    </div>
                     <div class="col narrow clickable" *ngIf="editable && canEdit" (click)="editReference(reference)">
-                        <mat-icon>edit</mat-icon>
+                        <mat-icon aria-label="edit">edit</mat-icon>
                     </div>
                 </div>
             </div>

--- a/app/src/app/components/resources-drawer/reference-manager/reference-manager.component.html
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-manager.component.html
@@ -25,7 +25,7 @@
                         <div class="text-label lowercase">{{reference.source_name}}</div>
                     </div>
                     <div class="col narrow clickable" (click)="openReference(false, reference)">
-                        <mat-icon aria-label="open">open_in_new</mat-icon>
+                        <mat-icon aria-label="view/edit reference">edit</mat-icon>
                     </div>
                 </div>
             </div>

--- a/app/src/app/components/resources-drawer/reference-manager/reference-manager.component.ts
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-manager.component.ts
@@ -43,7 +43,7 @@ export class ReferenceManagerComponent implements OnInit, AfterViewInit {
         let subscription = ref.afterClosed().subscribe({
             complete: () => {
                 this.applyControls(this.search.nativeElement.value);
-                subscription.unsubscribe()
+                subscription.unsubscribe();
             }
         });
     }

--- a/app/src/app/components/resources-drawer/reference-manager/reference-manager.component.ts
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-manager.component.ts
@@ -32,32 +32,19 @@ export class ReferenceManagerComponent implements OnInit, AfterViewInit {
     
     constructor(private restApiConnector: RestApiConnectorService, public snackbar: MatSnackBar, public dialog: MatDialog, private authenticationService: AuthenticationService) { }
 
-    public editReference(reference?: ExternalReference) {
+    public openReference(edit: boolean = false, reference?: ExternalReference) {
         let ref = this.dialog.open(ReferenceEditDialogComponent, {
             maxHeight: "75vh",
             data: {
-                mode: 'edit',
+                mode: edit ? 'edit' : 'view',
                 reference: reference
             }
         });
         let subscription = ref.afterClosed().subscribe({
             complete: () => {
-                this.applyControls();
-                subscription.unsubscribe();
+                this.applyControls(this.search.nativeElement.value);
+                subscription.unsubscribe()
             }
-        });
-    }
-
-    public viewReference(reference: ExternalReference) {
-        let ref = this.dialog.open(ReferenceEditDialogComponent, {
-            maxHeight: "75vh",
-            data: {
-                mode: 'view',
-                reference: reference
-            }
-        });
-        let subscription = ref.afterClosed().subscribe({
-            complete: () => subscription.unsubscribe()
         });
     }
 

--- a/app/src/app/components/resources-drawer/reference-manager/reference-manager.component.ts
+++ b/app/src/app/components/resources-drawer/reference-manager/reference-manager.component.ts
@@ -36,15 +36,29 @@ export class ReferenceManagerComponent implements OnInit, AfterViewInit {
         let ref = this.dialog.open(ReferenceEditDialogComponent, {
             maxHeight: "75vh",
             data: {
+                mode: 'edit',
                 reference: reference
             }
-        })
+        });
         let subscription = ref.afterClosed().subscribe({
             complete: () => {
                 this.applyControls();
                 subscription.unsubscribe();
             }
-        })
+        });
+    }
+
+    public viewReference(reference: ExternalReference) {
+        let ref = this.dialog.open(ReferenceEditDialogComponent, {
+            maxHeight: "75vh",
+            data: {
+                mode: 'view',
+                reference: reference
+            }
+        });
+        let subscription = ref.afterClosed().subscribe({
+            complete: () => subscription.unsubscribe()
+        });
     }
 
     /**


### PR DESCRIPTION
Adds a reference view page. Summary of changes:
- After creating a new reference, the reference is shown in the view dialog, s.t. users can copy the citation without a separate search and check to ensure the reference is correct
- The option to edit a reference moved from the reference list to the reference view dialog
- Fixes a bug where an existing reference search query was no longer applied after viewing & closing a reference

Resolves #304 