### PR TITLE
Add contributor field to tactics & techniques

### DIFF
--- a/app/src/app/classes/stix/tactic.ts
+++ b/app/src/app/classes/stix/tactic.ts
@@ -7,6 +7,7 @@ import { logger } from "../../util/logger";
 export class Tactic extends StixObject {
     public name: string = "";
     public domains: string[] = [];
+    public contributors: string[] = [];
     
     public readonly supportsAttackID = true;
     protected get attackIDValidator() { return {
@@ -34,6 +35,7 @@ export class Tactic extends StixObject {
         rep.stix.name = this.name;
         rep.stix.x_mitre_domains = this.domains;
         rep.stix.x_mitre_shortname = this.shortname;
+        rep.stix.x_mitre_contributors = this.contributors;
 
         return rep;
     }
@@ -56,6 +58,11 @@ export class Tactic extends StixObject {
                 if (this.isStringArray(sdo.x_mitre_domains)) this.domains = sdo.x_mitre_domains;
                 else logger.error("TypeError: domains field is not a string array.");
             } else this.domains = [];
+
+            if ("x_mitre_contributors" in sdo) {
+                if (this.isStringArray(sdo.x_mitre_contributors)) this.contributors = sdo.x_mitre_contributors;
+                else logger.error("TypeError: x_mitre_contributors is not a string array:", sdo.x_mitre_contributors, "(",typeof(sdo.x_mitre_contributors),")")
+            } else this.contributors = [];
         }
     }
 

--- a/app/src/app/classes/stix/technique.ts
+++ b/app/src/app/classes/stix/technique.ts
@@ -19,6 +19,7 @@ export class Technique extends StixObject {
     public defense_bypassed: string[] = [];
     public effective_permissions: string[] = [];
     public impact_type: string[] = [];
+    public contributors: string[] = [];
 
     public supports_remote: boolean = false;
     public requires_network: boolean = false;
@@ -99,6 +100,7 @@ export class Technique extends StixObject {
         rep.stix.x_mitre_platforms = this.platforms;
         rep.stix.kill_chain_phases = this.kill_chain_phases;
         rep.stix.x_mitre_is_subtechnique = this.is_subtechnique;
+        rep.stix.x_mitre_contributors = this.contributors;
 
         // domain specific fields
         if (this.domains.includes('ics-attack')) {
@@ -235,6 +237,11 @@ export class Technique extends StixObject {
                 if (this.isStringArray(sdo.x_mitre_effective_permissions)) this.effective_permissions = sdo.x_mitre_effective_permissions;
                 else logger.error("TypeError: effective permissions field is not a string array.");
             }
+
+            if ("x_mitre_contributors" in sdo) {
+                if (this.isStringArray(sdo.x_mitre_contributors)) this.contributors = sdo.x_mitre_contributors;
+                else logger.error("TypeError: x_mitre_contributors is not a string array:", sdo.x_mitre_contributors, "(",typeof(sdo.x_mitre_contributors),")")
+            } else this.contributors = [];
 
             if ("external_references" in sdo) {
                 if (typeof(sdo.external_references) === "object") {

--- a/app/src/app/components/stix/list-property/list-edit/list-edit.component.html
+++ b/app/src/app/components/stix/list-property/list-edit/list-edit.component.html
@@ -1,7 +1,6 @@
 <div class="list-edit grow-to-row">
     <mat-form-field *ngIf="!config.editType || config.editType == 'any'" class="grow-to-row" appearance="outline">
         <mat-label>{{config.label? config.label : config.field}}</mat-label>
-        <mat-card-content>
         <mat-chip-list #anyChipList [required]="config.required ? config.required : false" [formControl]="inputControl">
             <mat-chip *ngFor="let value of config.object[config.field]" [removable]="true" (removed)="remove(value)">
                 {{value}} <mat-icon matChipRemove>cancel</mat-icon>
@@ -13,7 +12,6 @@
                     [matChipInputAddOnBlur]="true"
                     (matChipInputTokenEnd)="add($event)"/>
         </mat-chip-list>
-        </mat-card-content>
     </mat-form-field>
 
     <mat-form-field *ngIf="config.editType == 'select'" class="grow-to-row" appearance="outline"

--- a/app/src/app/components/stix/list-property/list-edit/list-edit.component.ts
+++ b/app/src/app/components/stix/list-property/list-edit/list-edit.component.ts
@@ -236,7 +236,6 @@ export class ListEditComponent implements OnInit, AfterContentChecked {
         if (i >= 0) {
             this.config.object[this.config.field].splice(i, 1);
         }
-        this.inputControl.setValue(this.config.object[this.config.field])
     }
 
     /** Remove selection from via chip cancel button */

--- a/app/src/app/views/stix/tactic/tactic-view/tactic-view.component.html
+++ b/app/src/app/views/stix/tactic/tactic-view/tactic-view.component.html
@@ -17,6 +17,15 @@
             }"></app-attackid-property>
         </div>
         <div class="col">
+            <!-- VERSION NUMBER -->
+            <app-version-property class="grow-to-row" [config]="{
+                mode: editing? 'edit' : 'view',
+                object: tactic
+            }"></app-version-property>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col">
             <!-- DOMAIN -->
             <app-list-property class="grow-to-row" [config]="{
                 mode: editing? 'edit' : 'view',
@@ -26,11 +35,13 @@
             }"></app-list-property>
         </div>
         <div class="col">
-            <!-- VERSION NUMBER -->
-            <app-version-property class="grow-to-row" [config]="{
+            <!-- CONTRIBUTORS -->
+            <app-list-property class="grow-to-row" [config]="{
                 mode: editing? 'edit' : 'view',
-                object: tactic
-            }"></app-version-property>
+                object: tactic,
+                field: 'contributors',
+                editType: 'any'
+            }"></app-list-property>
         </div>
     </div>
     <div class="row">

--- a/app/src/app/views/stix/technique/technique-view/technique-view.component.html
+++ b/app/src/app/views/stix/technique/technique-view/technique-view.component.html
@@ -97,6 +97,15 @@
                 editType: 'select'
             }"></app-list-property>
         </div>
+        <div class="col">
+            <!-- CONTRIBUTORS -->
+            <app-list-property class="grow-to-row" [config]="{
+                mode: editing? 'edit' : 'view',
+                object: technique,
+                field: 'contributors',
+                editType: 'any'
+            }"></app-list-property>
+        </div>
     </div>
     <!-- ADDITIONAL IDs -->
     <div *ngIf="technique.capec_ids.length || (editing && technique.domains.includes('enterprise-attack'))" class="row">


### PR DESCRIPTION
Summary of changes:
- Adds serialization/deserialization of `x_mitre_contributors` field to Tactic and Technique objects
- Adds viewing/editing contributors on Tactic and Technique pages
- Fixes a bug in the contributors field where the input would populate with the remaining values in the list when the user removes a contributor

Resolves #325 