### PR TITLE
Disable revoke/deprecated checkboxes until all objects are loaded, to…

### DIFF
--- a/app/src/app/components/object-status/object-status.component.html
+++ b/app/src/app/components/object-status/object-status.component.html
@@ -17,8 +17,8 @@
         </mat-form-field>
 
         <div class="status-options">
-            <mat-checkbox [(ngModel)]="revoked" (change)="revoke($event)" [disabled]="deprecated" [class.disabled]="deprecated">Revoke</mat-checkbox>
-            <mat-checkbox [(ngModel)]="deprecated" (change)="deprecate($event)" [disabled]="revoked" [class.disabled]="revoked">Deprecate</mat-checkbox>
+            <mat-checkbox [(ngModel)]="revoked" (change)="revoke($event)" [disabled]="deprecated || !objects" [class.disabled]="deprecated || !objects">Revoke</mat-checkbox>
+            <mat-checkbox [(ngModel)]="deprecated" (change)="deprecate($event)" [disabled]="revoked || !objects" [class.disabled]="revoked || !objects">Deprecate</mat-checkbox>
         </div>
     </div>
     <ng-template #loading>


### PR DESCRIPTION
This PR addresses bug found where when user clicks on the `settings` icon in a object view page, and checks the `Revoke` box, it does not trigger the dialog box to select a revoking object.

The bug occurred when the dialog box was triggered before it finished loading all revoking objects successfully.