### PR TITLE
Fix for revoked-by relationship pop-up

### DIFF
--- a/app/src/app/services/connectors/rest-api/rest-api-connector.service.ts
+++ b/app/src/app/services/connectors/rest-api/rest-api-connector.service.ts
@@ -102,7 +102,10 @@ export class RestApiConnectorService extends ApiConnector {
      */
     private getObjectName(object: StixObject): string {
         if (object.type == "relationship") {
-            return `${object["source_name"]} ${object["relationship_type"]} ${object["target_name"]}`
+            if (object["source_name"] != '[unknown object]' && object["target_name"] != '[unknown object]') {
+                return `${object["source_name"]} ${object["relationship_type"]} ${object["target_name"]}`;
+            }
+            return `${object["relationship_type"].charAt(0).toUpperCase()}${object["relationship_type"].slice(1)} relationship`;
         } else if (object.type == "note") {
             return object["title"];
         } else if ("name" in object) {

--- a/app/src/app/services/connectors/rest-api/rest-api-connector.service.ts
+++ b/app/src/app/services/connectors/rest-api/rest-api-connector.service.ts
@@ -102,10 +102,10 @@ export class RestApiConnectorService extends ApiConnector {
      */
     private getObjectName(object: StixObject): string {
         if (object.type == "relationship") {
-            if (object["source_name"] != '[unknown object]' && object["target_name"] != '[unknown object]') {
-                return `${object["source_name"]} ${object["relationship_type"]} ${object["target_name"]}`;
+            if (object["source_name"] == '[unknown object]' || object["target_name"] == '[unknown object]') {
+                return `${object["relationship_type"].charAt(0).toUpperCase()}${object["relationship_type"].slice(1)} relationship`;
             }
-            return `${object["relationship_type"].charAt(0).toUpperCase()}${object["relationship_type"].slice(1)} relationship`;
+            return `${object["source_name"]} ${object["relationship_type"]} ${object["target_name"]}`;
         } else if (object.type == "note") {
             return object["title"];
         } else if ("name" in object) {


### PR DESCRIPTION
Fixes a visual bug in the snackbar that appears after successfully revoking an object, the popup appears as `[unknown object] revoked by [unknown object]`.

The bug was caused by accessing the optional `source_object` and `target_object` variables which are not defined when creating a `revoked-by` relationship object.