### PR TITLE
copy LinkByIds

### DIFF
--- a/app/src/app/components/stix/attackid-property/attackid-property.component.html
+++ b/app/src/app/components/stix/attackid-property/attackid-property.component.html
@@ -1,7 +1,12 @@
 <div class="attackid-property grow-to-row">
-    <div class="labelled-box grow-to-row" *ngIf="!config.mode || config.mode == 'view'">
+    <div *ngIf="!config.mode || config.mode == 'view'" class="labelled-box grow-to-row">
         <div class="content">
             <app-attackid-view [config]="config"></app-attackid-view>
+            <button mat-icon-button *ngIf="config.object['attackID']" [cdkCopyToClipboard]="linkById"
+                (click)="snackbar.open('LinkById copied to clipboard', null, {duration: 1000})"
+                matTooltip="copy linkById" aria-label="copy linkById">
+                <mat-icon>content_copy</mat-icon>
+            </button>
         </div>
         <label>ID</label>
     </div>

--- a/app/src/app/components/stix/attackid-property/attackid-property.component.html
+++ b/app/src/app/components/stix/attackid-property/attackid-property.component.html
@@ -1,6 +1,6 @@
 <div class="attackid-property grow-to-row">
     <div *ngIf="!config.mode || config.mode == 'view'" class="labelled-box grow-to-row">
-        <div class="content">
+        <div class="content" [ngClass]="{'icon-button': config.object['attackID']}">
             <app-attackid-view [config]="config"></app-attackid-view>
             <button mat-icon-button *ngIf="config.object['attackID']" [cdkCopyToClipboard]="linkById"
                 (click)="snackbar.open('LinkById copied to clipboard', null, {duration: 1000})"

--- a/app/src/app/components/stix/attackid-property/attackid-property.component.scss
+++ b/app/src/app/components/stix/attackid-property/attackid-property.component.scss
@@ -1,0 +1,3 @@
+.content.icon-button {
+    padding: 10px 12px !important;
+}

--- a/app/src/app/components/stix/attackid-property/attackid-property.component.ts
+++ b/app/src/app/components/stix/attackid-property/attackid-property.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { StixObject } from 'src/app/classes/stix/stix-object';
 
 @Component({
@@ -6,14 +7,13 @@ import { StixObject } from 'src/app/classes/stix/stix-object';
   templateUrl: './attackid-property.component.html',
   styleUrls: ['./attackid-property.component.scss']
 })
-export class AttackIDPropertyComponent implements OnInit {
+export class AttackIDPropertyComponent {
     @Input() public config: AttackIDPropertyConfig;
+    public get linkById(): string { return `(LinkById: ${this.config.object["attackID"]})`; }
 
-    constructor() { }
-
-    ngOnInit(): void {
+    constructor(public snackbar: MatSnackBar) {
+        // intentionally left blank
     }
-
 }
 export interface AttackIDPropertyConfig {
     /* What is the current mode? Default: 'view


### PR DESCRIPTION
Adds a button to the ATT&CK ID field to copy the object's LinkById tag in the format `(LinkById: <ATT&CK ID>)`. 

Resolves #327 