### PR TITLE
Feature/#350 delete references

### DIFF
--- a/app/src/app/components/delete-dialog/delete-dialog.component.html
+++ b/app/src/app/components/delete-dialog/delete-dialog.component.html
@@ -1,5 +1,6 @@
 <div class="delete-dialog">
     <h2>Are you sure you want to delete this object?</h2>
+    <h4 *ngIf="config.hardDelete">WARNING: This object will be permanently deleted.</h4>
     <div class="confirm-form">
         <span>Please type <strong>DELETE</strong> to confirm.</span>
         <mat-form-field appearance="outline">

--- a/app/src/app/components/delete-dialog/delete-dialog.component.ts
+++ b/app/src/app/components/delete-dialog/delete-dialog.component.ts
@@ -1,5 +1,5 @@
-import { Component, ViewEncapsulation } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
+import { Component, Inject, ViewEncapsulation } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 @Component({
     selector: 'app-delete-dialog',
@@ -14,7 +14,7 @@ export class DeleteDialogComponent {
         return this.confirmInput != this.deleteConfirmation;
     }
 
-    constructor(public dialogRef: MatDialogRef<DeleteDialogComponent>) { }
+    constructor(@Inject(MAT_DIALOG_DATA) public config: any, public dialogRef: MatDialogRef<DeleteDialogComponent>) { }
 
     public confirm() {
         this.dialogRef.close(true);

--- a/app/src/app/components/reference-edit-dialog/reference-edit-dialog.component.html
+++ b/app/src/app/components/reference-edit-dialog/reference-edit-dialog.component.html
@@ -11,6 +11,7 @@
             </button>
             <button *ngIf="!editing" mat-button class="control" matTooltip="edit" (click)="startEditing()"><mat-icon aria-label="edit">edit</mat-icon></button>
             <button *ngIf="editing"  mat-button class="control" matTooltip="discard changes & stop editing" (click)="discardChanges()"><mat-icon aria-label="discard">edit_off</mat-icon></button>
+            <button mat-button class="control" matTooltip="delete" [disabled]="!editing || config.count > 0" (click)="delete()"><mat-icon aria-label="delete">delete</mat-icon></button>
         </ng-container>
     </mat-toolbar>
     <!-- edit page -->

--- a/app/src/app/components/reference-edit-dialog/reference-edit-dialog.component.ts
+++ b/app/src/app/components/reference-edit-dialog/reference-edit-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { FormControl, ValidationErrors, Validators } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { forkJoin, Observable, of, Subscription, throwError } from 'rxjs';
 import { ExternalReference } from 'src/app/classes/external-references';
@@ -8,6 +8,7 @@ import { Relationship } from 'src/app/classes/stix/relationship';
 import { StixObject } from 'src/app/classes/stix/stix-object';
 import { AuthenticationService } from 'src/app/services/connectors/authentication/authentication.service';
 import { RestApiConnectorService } from 'src/app/services/connectors/rest-api/rest-api-connector.service';
+import { DeleteDialogComponent } from '../delete-dialog/delete-dialog.component';
 
 @Component({
   selector: 'app-reference-edit-dialog',
@@ -38,7 +39,8 @@ export class ReferenceEditDialogComponent implements OnInit, OnDestroy {
                 public dialogRef: MatDialogRef<ReferenceEditDialogComponent>,
                 public restApiConnectorService: RestApiConnectorService,
                 public snackbar: MatSnackBar,
-                private authenticationService: AuthenticationService) {
+                private authenticationService: AuthenticationService,
+                private dialog: MatDialog) {
         if (this.config.reference) {
             this.is_new = false;
             this.reference = JSON.parse(JSON.stringify(this.config.reference)); //deep copy
@@ -243,6 +245,28 @@ export class ReferenceEditDialogComponent implements OnInit, OnDestroy {
 
     public close(): void {
         this.dialogRef.close(this.dirty);
+    }
+
+    /** Opens the deletion confirmation dialog and deletes the reference */
+    public delete(): void {
+        let prompt = this.dialog.open(DeleteDialogComponent, {
+            maxWidth: "35em",
+            data: {
+                hardDelete: true
+            },
+            disableClose: true,
+            autoFocus: false // disables auto focus on the dialog form field
+        });
+        let subscription = prompt.afterClosed().subscribe({
+            next: (confirm) => {
+                if (confirm) {
+                    // delete the reference
+                    console.log('** todo delete reference');
+                    this.close();
+                }
+            },
+            complete: () => { subscription.unsubscribe(); }
+        })
     }
 }
 

--- a/app/src/app/views/reference-manager/reference-manager.component.ts
+++ b/app/src/app/views/reference-manager/reference-manager.component.ts
@@ -84,7 +84,8 @@ export class ReferenceManagerComponent implements OnInit, AfterViewInit, OnDestr
             maxHeight: "75vh",
             data: {
                 mode: reference ? 'view' : 'edit',
-                reference: reference
+                reference: reference,
+                count: this.referenceCount(reference.source_name)
             }
         });
         let subscription = prompt.afterClosed().subscribe({


### PR DESCRIPTION
Summary of changes:
- Adds the ability to delete a reference that is not used by any objects

In progress:
- Need to resolve `DELETE` endpoint for references. See [rest-api#199](https://github.com/center-for-threat-informed-defense/attack-workbench-rest-api/issues/199).

Resolves #350 