### PR TITLE
Delete Mitigations, Software, and Groups

### DIFF
--- a/app/src/app/app-routing-stix.module.ts
+++ b/app/src/app/app-routing-stix.module.ts
@@ -10,6 +10,7 @@ import { TacticListComponent } from './views/stix/tactic/tactic-list/tactic-list
 import { TechniqueListComponent } from './views/stix/technique/technique-list/technique-list.component';
 import { MarkingDefinitionListComponent } from "./views/stix/marking-definition/marking-definition-list/marking-definition-list.component";
 import { DataSourceListComponent } from "./views/stix/data-source/data-source-list/data-source-list.component";
+import { ReferenceManagerComponent } from "./views/reference-manager/reference-manager.component";
 
 import { StixPageComponent } from "./views/stix/stix-page/stix-page.component";
 
@@ -18,7 +19,6 @@ import { NgModule } from '@angular/core';
 import { environment } from "../environments/environment"
 import { AuthorizationGuard } from "./services/helpers/authorization.guard";
 import { Role } from "./classes/authn/role";
-import { ReferenceManagerComponent } from "./views/reference-manager/reference-manager.component";
 
 var viewRoles = [Role.VISITOR, Role.EDITOR, Role.ADMIN];
 var editRoles = [Role.EDITOR, Role.ADMIN];

--- a/app/src/app/classes/stix/collection.ts
+++ b/app/src/app/classes/stix/collection.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { RestApiConnectorService } from 'src/app/services/connectors/rest-api/rest-api-connector.service';
 import { ValidationData } from '../serializable';
 import { Group } from './group';
@@ -395,7 +395,8 @@ export class Collection extends StixObject {
         return postObservable;
     }
 
-    public delete(restAPIService: RestApiConnectorService): void {
+    public delete(restAPIService: RestApiConnectorService): Observable<{}> {
         // deletion is not supported on Collections
+        return of({});
     }
 }

--- a/app/src/app/classes/stix/collection.ts
+++ b/app/src/app/classes/stix/collection.ts
@@ -394,4 +394,8 @@ export class Collection extends StixObject {
         })
         return postObservable;
     }
+
+    public delete(restAPIService: RestApiConnectorService): void {
+        // deletion is not supported on Collections
+    }
 }

--- a/app/src/app/classes/stix/collection.ts
+++ b/app/src/app/classes/stix/collection.ts
@@ -395,7 +395,7 @@ export class Collection extends StixObject {
         return postObservable;
     }
 
-    public delete(restAPIService: RestApiConnectorService): Observable<{}> {
+    public delete(_restAPIService: RestApiConnectorService): Observable<{}> {
         // deletion is not supported on Collections
         return of({});
     }

--- a/app/src/app/classes/stix/data-component.ts
+++ b/app/src/app/classes/stix/data-component.ts
@@ -101,10 +101,11 @@ export class DataComponent extends StixObject {
      * Delete this STIX object from the database.
      * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
      */
-     public delete(restAPIService: RestApiConnectorService) : void {
+     public delete(restAPIService: RestApiConnectorService) : Observable<{}> {
         let deleteObservable = restAPIService.deleteDataComponent(this.stixID, this.modified);
         let subscription = deleteObservable.subscribe({
             complete: () => { subscription.unsubscribe(); }
         });
+        return deleteObservable;
     }
 }

--- a/app/src/app/classes/stix/data-component.ts
+++ b/app/src/app/classes/stix/data-component.ts
@@ -96,4 +96,15 @@ export class DataComponent extends StixObject {
         });
         return postObservable;
     }
+
+    /**
+     * Delete this STIX object from the database.
+     * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
+     */
+     public delete(restAPIService: RestApiConnectorService) : void {
+        let deleteObservable = restAPIService.deleteDataComponent(this.stixID, this.modified);
+        let subscription = deleteObservable.subscribe({
+            complete: () => { subscription.unsubscribe(); }
+        });
+    }
 }

--- a/app/src/app/classes/stix/data-source.ts
+++ b/app/src/app/classes/stix/data-source.ts
@@ -123,10 +123,11 @@ export class DataSource extends StixObject {
      * Delete this STIX object from the database.
      * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
      */
-    public delete(restAPIService: RestApiConnectorService) : void {
+    public delete(restAPIService: RestApiConnectorService) : Observable<{}> {
         let deleteObservable = restAPIService.deleteDataSource(this.stixID, this.modified);
         let subscription = deleteObservable.subscribe({
             complete: () => { subscription.unsubscribe(); }
         });
+        return deleteObservable;
     }
 }

--- a/app/src/app/classes/stix/data-source.ts
+++ b/app/src/app/classes/stix/data-source.ts
@@ -118,4 +118,15 @@ export class DataSource extends StixObject {
         });
         return postObservable;
     }
+
+    /**
+     * Delete this STIX object from the database.
+     * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
+     */
+    public delete(restAPIService: RestApiConnectorService) : void {
+        let deleteObservable = restAPIService.deleteDataSource(this.stixID, this.modified);
+        let subscription = deleteObservable.subscribe({
+            complete: () => { subscription.unsubscribe(); }
+        });
+    }
 }

--- a/app/src/app/classes/stix/group.ts
+++ b/app/src/app/classes/stix/group.ts
@@ -93,10 +93,11 @@ export class Group extends StixObject {
      * Delete this STIX object from the database.
      * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
      */
-    public delete(restAPIService: RestApiConnectorService) : void {
+    public delete(restAPIService: RestApiConnectorService) : Observable<{}> {
         let deleteObservable = restAPIService.deleteGroup(this.stixID, this.modified);
         let subscription = deleteObservable.subscribe({
             complete: () => { subscription.unsubscribe(); }
         });
+        return deleteObservable;
     }
 }

--- a/app/src/app/classes/stix/group.ts
+++ b/app/src/app/classes/stix/group.ts
@@ -88,4 +88,15 @@ export class Group extends StixObject {
         });
         return postObservable;
     }
+
+    /**
+     * Delete this STIX object from the database.
+     * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
+     */
+    public delete(restAPIService: RestApiConnectorService) : void {
+        let deleteObservable = restAPIService.deleteSoftware(this.stixID, this.modified);
+        let subscription = deleteObservable.subscribe({
+            complete: () => { subscription.unsubscribe(); }
+        });
+    }
 }

--- a/app/src/app/classes/stix/group.ts
+++ b/app/src/app/classes/stix/group.ts
@@ -94,7 +94,7 @@ export class Group extends StixObject {
      * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
      */
     public delete(restAPIService: RestApiConnectorService) : void {
-        let deleteObservable = restAPIService.deleteSoftware(this.stixID, this.modified);
+        let deleteObservable = restAPIService.deleteGroup(this.stixID, this.modified);
         let subscription = deleteObservable.subscribe({
             complete: () => { subscription.unsubscribe(); }
         });

--- a/app/src/app/classes/stix/identity.ts
+++ b/app/src/app/classes/stix/identity.ts
@@ -91,4 +91,8 @@ export class Identity extends StixObject {
         });
         return postObservable;
     }
+
+    public delete(restAPIService: RestApiConnectorService): void {
+        // deletion is not supported on Identity objects
+    }
 }

--- a/app/src/app/classes/stix/identity.ts
+++ b/app/src/app/classes/stix/identity.ts
@@ -1,4 +1,4 @@
-import { Observable } from "rxjs";
+import { Observable, of } from "rxjs";
 import { RestApiConnectorService } from "src/app/services/connectors/rest-api/rest-api-connector.service";
 import { ValidationData } from "../serializable";
 import { StixObject } from "./stix-object";
@@ -92,7 +92,8 @@ export class Identity extends StixObject {
         return postObservable;
     }
 
-    public delete(restAPIService: RestApiConnectorService): void {
+    public delete(restAPIService: RestApiConnectorService): Observable<{}> {
         // deletion is not supported on Identity objects
+        return of({});
     }
 }

--- a/app/src/app/classes/stix/identity.ts
+++ b/app/src/app/classes/stix/identity.ts
@@ -92,7 +92,7 @@ export class Identity extends StixObject {
         return postObservable;
     }
 
-    public delete(restAPIService: RestApiConnectorService): Observable<{}> {
+    public delete(_restAPIService: RestApiConnectorService): Observable<{}> {
         // deletion is not supported on Identity objects
         return of({});
     }

--- a/app/src/app/classes/stix/marking-definition.ts
+++ b/app/src/app/classes/stix/marking-definition.ts
@@ -1,7 +1,7 @@
 import { map, switchMap } from "rxjs/operators";
 import { StixObject } from "./stix-object";
 import { RestApiConnectorService } from "src/app/services/connectors/rest-api/rest-api-connector.service";
-import { Observable } from "rxjs";
+import { Observable, of } from "rxjs";
 import { ValidationData } from "../serializable";
 import { logger } from "../../util/logger";
 
@@ -131,7 +131,8 @@ export class MarkingDefinition extends StixObject {
         return postObservable;
     }
 
-    public delete(restAPIService: RestApiConnectorService): void {
+    public delete(restAPIService: RestApiConnectorService): Observable<{}> {
         // deletion is not supported on Marking Definitions
+        return of({});
     }
 }

--- a/app/src/app/classes/stix/marking-definition.ts
+++ b/app/src/app/classes/stix/marking-definition.ts
@@ -130,4 +130,8 @@ export class MarkingDefinition extends StixObject {
         });
         return postObservable;
     }
+
+    public delete(restAPIService: RestApiConnectorService): void {
+        // deletion is not supported on Marking Definitions
+    }
 }

--- a/app/src/app/classes/stix/marking-definition.ts
+++ b/app/src/app/classes/stix/marking-definition.ts
@@ -131,7 +131,7 @@ export class MarkingDefinition extends StixObject {
         return postObservable;
     }
 
-    public delete(restAPIService: RestApiConnectorService): Observable<{}> {
+    public delete(_restAPIService: RestApiConnectorService): Observable<{}> {
         // deletion is not supported on Marking Definitions
         return of({});
     }

--- a/app/src/app/classes/stix/matrix.ts
+++ b/app/src/app/classes/stix/matrix.ts
@@ -82,4 +82,8 @@ export class Matrix extends StixObject {
         });
         return postObservable;
     }
+
+    public delete(restAPIService: RestApiConnectorService): void {
+        // deletion is not supported on Matrix objects
+    }
 }

--- a/app/src/app/classes/stix/matrix.ts
+++ b/app/src/app/classes/stix/matrix.ts
@@ -83,7 +83,7 @@ export class Matrix extends StixObject {
         return postObservable;
     }
 
-    public delete(restAPIService: RestApiConnectorService): Observable<{}> {
+    public delete(_restAPIService: RestApiConnectorService): Observable<{}> {
         // deletion is not supported on Matrix objects
         return of({});
     }

--- a/app/src/app/classes/stix/matrix.ts
+++ b/app/src/app/classes/stix/matrix.ts
@@ -1,4 +1,4 @@
-import { Observable } from "rxjs";
+import { Observable, of } from "rxjs";
 import { RestApiConnectorService } from "src/app/services/connectors/rest-api/rest-api-connector.service";
 import { ValidationData } from "../serializable";
 import { StixObject } from "./stix-object";
@@ -83,7 +83,8 @@ export class Matrix extends StixObject {
         return postObservable;
     }
 
-    public delete(restAPIService: RestApiConnectorService): void {
+    public delete(restAPIService: RestApiConnectorService): Observable<{}> {
         // deletion is not supported on Matrix objects
+        return of({});
     }
 }

--- a/app/src/app/classes/stix/mitigation.ts
+++ b/app/src/app/classes/stix/mitigation.ts
@@ -85,10 +85,11 @@ export class Mitigation extends StixObject {
      * Delete this STIX object from the database.
      * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
      */
-    public delete(restAPIService: RestApiConnectorService) : void {
+    public delete(restAPIService: RestApiConnectorService) : Observable<{}> {
         let deleteObservable = restAPIService.deleteMitigation(this.stixID, this.modified);
         let subscription = deleteObservable.subscribe({
             complete: () => { subscription.unsubscribe(); }
         });
+        return deleteObservable;
     }
 }

--- a/app/src/app/classes/stix/mitigation.ts
+++ b/app/src/app/classes/stix/mitigation.ts
@@ -80,4 +80,15 @@ export class Mitigation extends StixObject {
         });
         return postObservable;
     }
+
+    /**
+     * Delete this STIX object from the database.
+     * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
+     */
+    public delete(restAPIService: RestApiConnectorService) : void {
+        let deleteObservable = restAPIService.deleteSoftware(this.stixID, this.modified);
+        let subscription = deleteObservable.subscribe({
+            complete: () => { subscription.unsubscribe(); }
+        });
+    }
 }

--- a/app/src/app/classes/stix/mitigation.ts
+++ b/app/src/app/classes/stix/mitigation.ts
@@ -86,7 +86,7 @@ export class Mitigation extends StixObject {
      * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
      */
     public delete(restAPIService: RestApiConnectorService) : void {
-        let deleteObservable = restAPIService.deleteSoftware(this.stixID, this.modified);
+        let deleteObservable = restAPIService.deleteMitigation(this.stixID, this.modified);
         let subscription = deleteObservable.subscribe({
             complete: () => { subscription.unsubscribe(); }
         });

--- a/app/src/app/classes/stix/note.ts
+++ b/app/src/app/classes/stix/note.ts
@@ -90,10 +90,11 @@ export class Note extends StixObject {
      * Delete this STIX object from the database.
      * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
      */
-    public delete(restAPIService: RestApiConnectorService) : void {
+    public delete(restAPIService: RestApiConnectorService) : Observable<{}> {
         let deleteObservable = restAPIService.deleteNote(this.stixID);
         let subscription = deleteObservable.subscribe({
             complete: () => { subscription.unsubscribe(); }
         });
+        return deleteObservable;
     }
 }

--- a/app/src/app/classes/stix/relationship.ts
+++ b/app/src/app/classes/stix/relationship.ts
@@ -429,10 +429,11 @@ export class Relationship extends StixObject {
      * Delete this STIX object from the database.
      * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
      */
-    public delete(restAPIService: RestApiConnectorService) : void {
+    public delete(restAPIService: RestApiConnectorService) : Observable<{}> {
         let deleteObservable = restAPIService.deleteRelationship(this.stixID, this.modified);
         let subscription = deleteObservable.subscribe({
             complete: () => { subscription.unsubscribe(); }
         });
+        return deleteObservable;
     }
 }

--- a/app/src/app/classes/stix/software.ts
+++ b/app/src/app/classes/stix/software.ts
@@ -117,10 +117,11 @@ export class Software extends StixObject {
      * Delete this STIX object from the database.
      * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
      */
-    public delete(restAPIService: RestApiConnectorService) : void {
+    public delete(restAPIService: RestApiConnectorService) : Observable<{}> {
         let deleteObservable = restAPIService.deleteSoftware(this.stixID, this.modified);
         let subscription = deleteObservable.subscribe({
             complete: () => { subscription.unsubscribe(); }
         });
+        return deleteObservable;
     }
 }

--- a/app/src/app/classes/stix/software.ts
+++ b/app/src/app/classes/stix/software.ts
@@ -112,4 +112,15 @@ export class Software extends StixObject {
         });
         return postObservable;
     }
+
+    /**
+     * Delete this STIX object from the database.
+     * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
+     */
+    public delete(restAPIService: RestApiConnectorService) : void {
+        let deleteObservable = restAPIService.deleteSoftware(this.stixID, this.modified);
+        let subscription = deleteObservable.subscribe({
+            complete: () => { subscription.unsubscribe(); }
+        });
+    }
 }

--- a/app/src/app/classes/stix/stix-object.ts
+++ b/app/src/app/classes/stix/stix-object.ts
@@ -536,6 +536,12 @@ export abstract class StixObject extends Serializable {
     abstract save(restAPIService: RestApiConnectorService): Observable<StixObject>;
 
     /**
+     * Delete the STIX object from the database.
+     * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
+     */
+    abstract delete(restAPIService: RestApiConnectorService): void;
+    
+    /**
      * Updates the object's marking definitions with the default the first time an object is created
      * @param restAPIService [RestApiConnectorService] the service to perform the POST/PUT through
      */

--- a/app/src/app/classes/stix/stix-object.ts
+++ b/app/src/app/classes/stix/stix-object.ts
@@ -539,7 +539,7 @@ export abstract class StixObject extends Serializable {
      * Delete the STIX object from the database.
      * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
      */
-    abstract delete(restAPIService: RestApiConnectorService): void;
+    abstract delete(restAPIService: RestApiConnectorService): Observable<{}>;
     
     /**
      * Updates the object's marking definitions with the default the first time an object is created

--- a/app/src/app/classes/stix/tactic.ts
+++ b/app/src/app/classes/stix/tactic.ts
@@ -91,4 +91,8 @@ export class Tactic extends StixObject {
         });
         return postObservable;
     }
+
+    public delete(restAPIService: RestApiConnectorService): void {
+        // deletion is not supported on Tactic objects
+    }
 }

--- a/app/src/app/classes/stix/tactic.ts
+++ b/app/src/app/classes/stix/tactic.ts
@@ -92,7 +92,7 @@ export class Tactic extends StixObject {
         return postObservable;
     }
 
-    public delete(restAPIService: RestApiConnectorService): Observable<{}> {
+    public delete(_restAPIService: RestApiConnectorService): Observable<{}> {
         // deletion is not supported on Tactic objects
         return of({});
     }

--- a/app/src/app/classes/stix/tactic.ts
+++ b/app/src/app/classes/stix/tactic.ts
@@ -1,4 +1,4 @@
-import { Observable } from "rxjs";
+import { Observable, of } from "rxjs";
 import { RestApiConnectorService } from "src/app/services/connectors/rest-api/rest-api-connector.service";
 import { ValidationData } from "../serializable";
 import {StixObject} from "./stix-object";
@@ -92,7 +92,8 @@ export class Tactic extends StixObject {
         return postObservable;
     }
 
-    public delete(restAPIService: RestApiConnectorService): void {
+    public delete(restAPIService: RestApiConnectorService): Observable<{}> {
         // deletion is not supported on Tactic objects
+        return of({});
     }
 }

--- a/app/src/app/classes/stix/technique.ts
+++ b/app/src/app/classes/stix/technique.ts
@@ -337,4 +337,15 @@ export class Technique extends StixObject {
         });
         return postObservable;
     }
+
+    /**
+     * Delete this STIX object from the database.
+     * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
+     */
+    public delete(restAPIService: RestApiConnectorService) : void {
+        let deleteObservable = restAPIService.deleteTechnique(this.stixID, this.modified);
+        let subscription = deleteObservable.subscribe({
+            complete: () => { subscription.unsubscribe(); }
+        });
+    }
 }

--- a/app/src/app/classes/stix/technique.ts
+++ b/app/src/app/classes/stix/technique.ts
@@ -342,10 +342,11 @@ export class Technique extends StixObject {
      * Delete this STIX object from the database.
      * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
      */
-    public delete(restAPIService: RestApiConnectorService) : void {
+    public delete(restAPIService: RestApiConnectorService) : Observable<{}> {
         let deleteObservable = restAPIService.deleteTechnique(this.stixID, this.modified);
         let subscription = deleteObservable.subscribe({
             complete: () => { subscription.unsubscribe(); }
         });
+        return deleteObservable;
     }
 }

--- a/app/src/app/components/toolbar/toolbar.component.html
+++ b/app/src/app/components/toolbar/toolbar.component.html
@@ -6,6 +6,7 @@
             <button mat-button class="control" matTooltip="validate & save" [disabled]="!editing" (click)="saveEdits()"><mat-icon aria-label="save">save</mat-icon></button>
             <button *ngIf="!editing" mat-button class="control" matTooltip="edit" (click)="startEditing()"><mat-icon aria-label="edit">edit</mat-icon></button>
             <button *ngIf="editing" mat-button class="control" matTooltip="discard changes & stop editing" (click)="stopEditing()"><mat-icon aria-label="discard">edit_off</mat-icon></button>
+            <button mat-button class="control" matTooltip="delete" [disabled]="!editing || !deletable" (click)="delete()"><mat-icon aria-label="delete">delete</mat-icon></button>
             <app-object-status></app-object-status>
         </div>
         <div class="controls button-list section">

--- a/app/src/app/components/toolbar/toolbar.component.ts
+++ b/app/src/app/components/toolbar/toolbar.component.ts
@@ -22,6 +22,7 @@ export class ToolbarComponent implements OnInit {
 
     public get editing(): boolean { return this.editorService.editing; }
     public get editable(): boolean { return this.editorService.editable; }
+    public get deletable(): boolean { return this.editorService.deletable; }
 
     public get isLoggedIn(): boolean { return this.authenticationService.isLoggedIn; }
 
@@ -41,6 +42,10 @@ export class ToolbarComponent implements OnInit {
 
     public saveEdits() {
         this.editorService.onSave.emit();
+    }
+
+    public delete() {
+        this.editorService.onDelete.emit();
     }
     
     // emit a toggle theme event

--- a/app/src/app/services/editor/editor.service.ts
+++ b/app/src/app/services/editor/editor.service.ts
@@ -40,7 +40,7 @@ export class EditorService {
                 this.sidebarService.setEnabled("notes", this.editable);
                 if (!this.editable) this.sidebarService.currentTab = "references";
                 if (this.editable) {
-                    var delSubscription = this.getDeletable().subscribe({
+                    let delSubscription = this.getDeletable().subscribe({
                         next: (res) => this.deletable = res && !this.router.url.includes("/new"),
                         complete: () => { if (delSubscription) delSubscription.unsubscribe(); }
                     })

--- a/app/src/app/services/editor/editor.service.ts
+++ b/app/src/app/services/editor/editor.service.ts
@@ -40,10 +40,9 @@ export class EditorService {
                 this.sidebarService.setEnabled("notes", this.editable);
                 if (!this.editable) this.sidebarService.currentTab = "references";
                 if (this.editable) {
-                    let delSubscription = this.getDeletable().subscribe({
-                        next: (res) => this.deletable = res && !this.router.url.includes("/new"),
-                        complete: () => { if (delSubscription) delSubscription.unsubscribe(); }
-                    })
+                    this.getDeletable().subscribe(res => {
+                        this.deletable = res && !this.router.url.includes("/new");
+                    });
                 }
             }
         })

--- a/app/src/app/services/editor/editor.service.ts
+++ b/app/src/app/services/editor/editor.service.ts
@@ -4,6 +4,9 @@ import { SidebarService } from '../sidebar/sidebar.service';
 import { ConfirmationDialogComponent } from 'src/app/components/confirmation-dialog/confirmation-dialog.component';
 import { MatDialog } from '@angular/material/dialog';
 import { AuthenticationService } from '../connectors/authentication/authentication.service';
+import { RestApiConnectorService } from '../connectors/rest-api/rest-api-connector.service';
+import { map } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
 
 @Injectable({
     providedIn: 'root'
@@ -11,6 +14,7 @@ import { AuthenticationService } from '../connectors/authentication/authenticati
 export class EditorService {
     public editable: boolean = false;
     public editing: boolean = false;
+    public deletable: boolean = false;
     public onSave = new EventEmitter();
     public onEditingStopped = new EventEmitter();
     public onReload = new EventEmitter();
@@ -24,6 +28,7 @@ export class EditorService {
         private route: ActivatedRoute,
         private sidebarService: SidebarService,
         private authenticationService: AuthenticationService,
+        private restAPIConnectorService: RestApiConnectorService,
         private dialog: MatDialog) {
         this.router.events.subscribe(event => {
             if (event instanceof NavigationEnd) {
@@ -33,6 +38,12 @@ export class EditorService {
                 this.sidebarService.setEnabled("history", this.editable);
                 this.sidebarService.setEnabled("notes", this.editable);
                 if (!this.editable) this.sidebarService.currentTab = "references";
+                if (this.editable) {
+                    var delSubscription = this.getDeletable().subscribe({
+                        next: (res) => this.deletable = res,
+                        complete: () => { if (delSubscription) delSubscription.unsubscribe(); }
+                    })
+                }
             }
         })
         this.route.queryParams.subscribe(params => {
@@ -75,5 +86,18 @@ export class EditorService {
             data.push(... this.getEditableFromRoute(state, state.firstChild(parent)));
         }
         return data;
+    }
+
+    /** 
+     * Determine whether or not this object can be deleted
+     * Software, Group, and Mitigation objects cannot be deleted if they have relationships with other objects
+     */
+    public getDeletable(): Observable<boolean> {
+        if (["software", "group", "mitigation"].includes(this.type)) {
+            return this.restAPIConnectorService.getRelatedTo({sourceOrTargetRef: this.stixId}).pipe(
+                map(relationships => relationships.data.length == 0)
+            )
+        }
+        return of(false);
     }
 }

--- a/app/src/app/services/editor/editor.service.ts
+++ b/app/src/app/services/editor/editor.service.ts
@@ -16,6 +16,7 @@ export class EditorService {
     public editing: boolean = false;
     public deletable: boolean = false;
     public onSave = new EventEmitter();
+    public onDelete = new EventEmitter();
     public onEditingStopped = new EventEmitter();
     public onReload = new EventEmitter();
     public onReloadReferences = new EventEmitter();

--- a/app/src/app/services/editor/editor.service.ts
+++ b/app/src/app/services/editor/editor.service.ts
@@ -41,7 +41,7 @@ export class EditorService {
                 if (!this.editable) this.sidebarService.currentTab = "references";
                 if (this.editable) {
                     var delSubscription = this.getDeletable().subscribe({
-                        next: (res) => this.deletable = res,
+                        next: (res) => this.deletable = res && !this.router.url.includes("/new"),
                         complete: () => { if (delSubscription) delSubscription.unsubscribe(); }
                     })
                 }

--- a/app/src/app/views/stix/stix-page/stix-page.component.ts
+++ b/app/src/app/views/stix/stix-page/stix-page.component.ts
@@ -108,7 +108,7 @@ export class StixPageComponent implements OnInit, OnDestroy {
             disableClose: true,
             autoFocus: false
         });
-        var closeSubscription = prompt.afterClosed().subscribe({
+        let closeSubscription = prompt.afterClosed().subscribe({
             next: (confirm) => {
                 if (confirm) {
                     let deleteSubscription = this.deleteObjects().subscribe({
@@ -137,13 +137,13 @@ export class StixPageComponent implements OnInit, OnDestroy {
     ngOnInit(): void {
         this.loadObjects();
         this.saveSubscription = this.editorService.onSave.subscribe({
-            next: (event) => this.save()
+            next: (_event) => this.save()
         });
         this.deleteSubscription = this.editorService.onDelete.subscribe({
-            next: (event) => this.delete()
+            next: (_event) => this.delete()
         });
         this.reloadSubscription = this.editorService.onReload.subscribe({
-            next: (event) => {
+            next: (_event) => {
                 this.objects = undefined;
                 this.loadObjects();
             }

--- a/app/src/app/views/stix/stix-page/stix-page.component.ts
+++ b/app/src/app/views/stix/stix-page/stix-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit, ViewChild, Output, EventEmitter } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
+import { Location } from '@angular/common';
 import { BreadcrumbService } from 'angular-crumbs';
 import { Observable, forkJoin } from 'rxjs';
 import { switchMap } from "rxjs/operators";
@@ -52,7 +53,8 @@ export class StixPageComponent implements OnInit, OnDestroy {
                 private breadcrumbService: BreadcrumbService, 
                 private editorService: EditorService,
                 private dialog: MatDialog,
-                private titleService: TitleService) { }
+                private titleService: TitleService,
+                private _location: Location) { }
     
     /**
      * Parse an object list and build a config for passing into child components
@@ -110,8 +112,10 @@ export class StixPageComponent implements OnInit, OnDestroy {
             next: (confirm) => {
                 if (confirm) {
                     let deleteSubscription = this.deleteObjects().subscribe({
-                        // TODO reroute back to list page
-                        complete: () => deleteSubscription.unsubscribe()
+                        complete: () => {
+                            this.router.navigate([this.route.parent.url])
+                            deleteSubscription.unsubscribe();
+                        }
                     });
                 }
             },

--- a/app/src/app/views/stix/stix-page/stix-page.component.ts
+++ b/app/src/app/views/stix/stix-page/stix-page.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnDestroy, OnInit, ViewChild, Output, EventEmitter } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
-import { Location } from '@angular/common';
 import { BreadcrumbService } from 'angular-crumbs';
 import { Observable, forkJoin } from 'rxjs';
 import { switchMap } from "rxjs/operators";
@@ -53,8 +52,7 @@ export class StixPageComponent implements OnInit, OnDestroy {
                 private breadcrumbService: BreadcrumbService, 
                 private editorService: EditorService,
                 private dialog: MatDialog,
-                private titleService: TitleService,
-                private _location: Location) { }
+                private titleService: TitleService) { }
     
     /**
      * Parse an object list and build a config for passing into child components


### PR DESCRIPTION
Summary of changes:
- Added a delete control to stix object toolbar, which is disabled if the objects have existing relationships or if the object has not yet been saved to the database
- Added deletion capabilities for Mitigation, Software and Group objects. All related notes are also deleted and the user is navigated back to the object's respective list page.

Resolves #342 