### PR TITLE
update integration docs for nav compatibility with Workbench v1.2.0

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -50,6 +50,11 @@ Edit the config file `nav-app/src/assets/config.json` by prepending a new object
         {
             "name": "ATT&CK Workbench Data",
             "version": "11",
+            "authentication": {
+                "enabled": true,
+                "serviceName": "navigator",
+                "apiKey": "sample-navigator-apikey"
+            },
             "domains": [
                 {
                     "name": "Enterprise",
@@ -71,8 +76,6 @@ Edit the config file `nav-app/src/assets/config.json` by prepending a new object
     ]
 }
 ```
-
-_Note: due to inflexibility of the data loading in Navigator v4.5.1, the version name must be _exactly_ two words and start with the word `"ATT&CK"`. The domain names must also exactly match those shown above. Version and domain name flexibility in ATT&CK Navigator will be improved in a future update. See [attack-navigator#370](https://github.com/mitre-attack/attack-navigator/issues/370) for more information._
 
 ### 3. Serve the application
 


### PR DESCRIPTION
Summary of changes:
- Adds the authentication configuration to the example version object
- Removes an outdated note that was fixed in [navigator#370](https://github.com/mitre-attack/attack-navigator/issues/370)