### PR TITLE
Optimize LinkByIds

### DIFF
--- a/app/src/app/classes/stix/stix-object.ts
+++ b/app/src/app/classes/stix/stix-object.ts
@@ -501,7 +501,7 @@ export abstract class StixObject extends Serializable {
         let ids = [];
         for (let link of links) {
             let id = link.split("(LinkById: ")[1].slice(0, -1);
-            if (!(id in ids)) ids.push(id);
+            if(!ids.includes(id)) ids.push(id);
         }
 
         return restAPIService.getAllObjects(ids, null, null, null, true, true, true).pipe(

--- a/app/src/app/classes/stix/stix-object.ts
+++ b/app/src/app/classes/stix/stix-object.ts
@@ -498,20 +498,17 @@ export abstract class StixObject extends Serializable {
 
         if (!links) return of(result); // no LinkByIds found
 
-        let link_map = {};
+        let ids = [];
         for (let link of links) {
             let id = link.split("(LinkById: ")[1].slice(0, -1);
-            if (!(id in link_map)) {
-                link_map[id] = this.findLink(id, restAPIService);
-            }
+            if (!(id in ids)) ids.push(id);
         }
 
-        return forkJoin(link_map).pipe(
-            map((results) => {
-                let link_results = results as any;
-                for (let key of Object.keys(link_results)) {
-                    // verify whether or not all links were found
-                    if (!link_results[key]) result.missingLinks.add(key);
+        return restAPIService.getAllObjects(ids, null, null, null, true, true, true).pipe(
+            map((results: any) => {
+                let retrieved_ids = (results.data as StixObject[]).map(obj => obj.attackID);
+                for (let id of ids) {
+                    if (!retrieved_ids.includes(id)) result.missingLinks.add(id);
                 }
                 return result;
             })
@@ -532,21 +529,6 @@ export abstract class StixObject extends Serializable {
             }
         }
         return result;
-    }
-
-    /**
-     * retrieves the linked object by ID
-     * @param id the ID of the linked object
-     * @param restAPIService service to connect to the REST API
-     */
-    private findLink(id: string, restAPIService: RestApiConnectorService): Observable<boolean> {
-        return restAPIService.getAllObjects(id, null, null, null, true, true, true).pipe(
-            map((result) => {
-                let object = result.data[0];
-                if (object) return true;
-                return false; // object not found
-            })
-        );
     }
 
     public isStringArray = function (arr): boolean {

--- a/app/src/app/components/stix/descriptive-property/descriptive-view/descriptive-view.component.ts
+++ b/app/src/app/components/stix/descriptive-property/descriptive-view/descriptive-view.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
-import { forkJoin, Observable, Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { StixObject } from 'src/app/classes/stix/stix-object';
 import { RestApiConnectorService } from 'src/app/services/connectors/rest-api/rest-api-connector.service';
 import { DescriptivePropertyConfig } from '../descriptive-property.component';
 
@@ -98,15 +99,11 @@ export class DescriptiveViewComponent implements OnInit {
      * @param ids list of IDs to retrieve
      */
     private loadLinkedObjects(ids: string[]): Observable<any> {
-        let api_map = {};
-        for (let id of ids) {
-            api_map[id] = this.restApiConnector.getAllObjects(id, null, null, null, true, true, true)
-        }
-
-        return forkJoin(api_map).pipe(
+        return this.restApiConnector.getAllObjects(ids, null, null, null, true, true, true).pipe(
             map((results: any) => {
+                let data = results.data as StixObject[];
                 // store retrieved objects in dictionary for quick lookup
-                Object.keys(results).forEach(id => this.objectLookup[id] = results[id].data[0]);
+                data.forEach(obj => this.objectLookup[obj.attackID] = obj);
                 return results;
             })
         );

--- a/app/src/app/services/connectors/rest-api/rest-api-connector.service.ts
+++ b/app/src/app/services/connectors/rest-api/rest-api-connector.service.ts
@@ -355,7 +355,7 @@ export class RestApiConnectorService extends ApiConnector {
 
     /**
      * Get all objects; objects will not be deserialized to STIX objects unless the parameter is used
-     * @param {string} [attackID] filter to only include objects with this ATT&CK ID
+     * @param {string[]} [attackIDs] filter to only include objects within the list of given ATT&CK IDs
      * @param {number} [limit] the number of collections to retrieve
      * @param {number} [offset] the number of collections to skip
      * @param {string} [state] if specified, only get objects with this state
@@ -365,14 +365,16 @@ export class RestApiConnectorService extends ApiConnector {
      * @param {boolean} [deserialize] if true, deserialize objects to full STIX objects
      * @returns {Observable<any[]>} observable of retrieved objects
      */
-    public getAllObjects(attackID?: string, limit?: number, offset?: number, state?: string, revoked?: boolean, deprecated?: boolean, deserialize?: boolean) {
+    public getAllObjects(attackIDs?: string[], limit?: number, offset?: number, state?: string, revoked?: boolean, deprecated?: boolean, deserialize?: boolean) {
         let query = new HttpParams({encoder: new CustomEncoder()});
         // pagination
         if (limit) query = query.set("limit", limit.toString());
         if (offset) query = query.set("offset", offset.toString());
         if (limit || offset) query = query.set("includePagination", "true");
         // other properties
-        if (attackID) query = query.set("attackId", attackID);
+        if (attackIDs) {
+            attackIDs.forEach(id => query = query.append("attackId", id));
+        }
         if (state) query = query.set("state", state);
         if (revoked) query = query.set("includeRevoked", revoked ? "true" : "false");
         if (deprecated) query = query.set("includeDeprecated", deprecated ? "true" : "false");


### PR DESCRIPTION
Update REST API Service retrieve all endpoint to support searching on multiple ATT&CK IDs. Related to [rest-api#225](https://github.com/center-for-threat-informed-defense/attack-workbench-rest-api/issues/225).