### PR TITLE
242 sync color theme with os settings

### DIFF
--- a/app/src/app/app.component.ts
+++ b/app/src/app/app.component.ts
@@ -1,12 +1,13 @@
-import { AfterViewInit, Component, ElementRef, ViewChild, ViewEncapsulation } from '@angular/core';
-import { MatDrawerContainer } from '@angular/material/sidenav';
-import { OverlayContainer } from '@angular/cdk/overlay';
-import { getCookie, setCookie, hasCookie } from "./util/cookies";
-import { SidebarService } from './services/sidebar/sidebar.service';
-import { NGXLogger } from 'ngx-logger';
-import { initLogger } from './util/logger';
-import { AuthenticationService } from './services/connectors/authentication/authentication.service';
-import { NavigationEnd, Router } from '@angular/router';
+import {OnInit, AfterViewInit, Component, ElementRef, ViewChild, ViewEncapsulation} from '@angular/core';
+import {MatDrawerContainer} from '@angular/material/sidenav';
+import {OverlayContainer} from '@angular/cdk/overlay';
+import {getCookie, hasCookie, setCookie} from "./util/cookies";
+import {SidebarService} from './services/sidebar/sidebar.service';
+import {NGXLogger} from 'ngx-logger';
+import {initLogger} from './util/logger';
+import {AuthenticationService} from './services/connectors/authentication/authentication.service';
+import {NavigationEnd, Router} from '@angular/router';
+import {Theme} from './globals';
 
 @Component({
   selector: 'app-root',
@@ -14,24 +15,28 @@ import { NavigationEnd, Router } from '@angular/router';
   styleUrls: ['./app.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
-export class AppComponent implements AfterViewInit {
-    //drawer container to resize when contents change size
-    @ViewChild(MatDrawerContainer, {static: true}) private container: MatDrawerContainer;
-    //elements for scroll behavior
-    @ViewChild("header", {static: false, read: ElementRef}) private header: ElementRef;
-    @ViewChild("scrollRef", {static: false, read: ElementRef}) private scrollRef: ElementRef;
+export class AppComponent implements AfterViewInit, OnInit {
 
+    // Drawer container to resize when contents change size
+    @ViewChild(MatDrawerContainer, {static: true}) private container: MatDrawerContainer;
+
+    // Elements for scroll behavior
+    @ViewChild('header', { static: false, read: ElementRef }) private header: ElementRef;
+    @ViewChild('scrollRef', { static: false, read: ElementRef }) private scrollRef: ElementRef;
+
+    public theme = Theme.DarkMode; // sets the default theme?
     public alertStatus;
+
     constructor(private overlayContainer: OverlayContainer,
                 private sidebarService: SidebarService,
                 private authenticationService: AuthenticationService,
                 private router: Router,
-                private logger: NGXLogger) { //note: this isn't used directly, but it MUST be imported to work properly
+                private logger: NGXLogger) { // Note: this isn't used directly, but it MUST be imported to work properly
 
-        if (hasCookie("theme")) {
-            this.setTheme(getCookie("theme"))
+        if (hasCookie('theme')) {
+            this.setTheme(getCookie('theme'));
         } else {
-            this.setTheme("light");
+            this.setTheme(Theme.LightMode);
         }
 
         const routerSubscription = this.router.events.subscribe({
@@ -99,25 +104,50 @@ export class AppComponent implements AfterViewInit {
         });
     }
 
-    public theme = "light";
-    //toggle the current theme
-    public toggleTheme() {
-        this.setTheme(this.theme == "light"? "dark" : "light");
+    // Toggle the current theme
+    public toggleTheme(): void {
+        // tslint:disable-next-line:triple-equals
+        this.setTheme(this.theme == Theme.LightMode ? Theme.DarkMode : Theme.LightMode);
     }
 
-    public setTheme(theme: string) {
-        this.logger.log("setting theme to", theme);
+    /**
+     * Sets the initial/default theme based on the operating system/browser settings. Called by ngOnInit.
+     */
+    public setDefaultTheme(): void {
+        // The theme property will be set to 'dark' if the operating system or browser is in dark mode, and 'light' if
+        // it is in light mode
+        const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
+        this.theme = mediaQueryList.matches ? Theme.DarkMode : Theme.LightMode;
+
+        // use the addEventListener method of the MediaQueryList object to set up a listener that will be called
+        // whenever the light/dark mode setting changes
+        mediaQueryList.addEventListener('change', (event) => {
+          this.theme = event.matches ? Theme.DarkMode : Theme.LightMode;
+        });
+    }
+
+    public setTheme(theme: string): void {
+        this.logger.log(`Setting theme to ${theme}`);
         this.theme = theme;
         const overlayContainerClasses = this.overlayContainer.getContainerElement().classList;
-        overlayContainerClasses.remove("dark", "light");
+        overlayContainerClasses.remove(Theme.DarkMode, Theme.LightMode);
         overlayContainerClasses.add(this.theme);
-        setCookie("theme", theme, 30);
+        setCookie('theme', theme, 30);
+    }
+
+    ngOnInit(): void {
+      this.setDefaultTheme();
     }
 
     // header hiding with scroll
     ngAfterViewInit() {
         this.scrollRef.nativeElement.addEventListener('scroll', (e) => this.adjustHeaderPlacement(), true);
         //to fix rare cases that the page has resized without scroll events triggering, recompute the offset every 5 seconds
+      /**
+       * The code is using the setInterval() function to call the adjustHeaderPlacement() method every 5
+       * seconds. This is likely intended to fix cases where the page has been resized without scroll events being
+       * triggered, in which case the header placement may need to be adjusted.
+       */
         setInterval(() => this.adjustHeaderPlacement(), 5000);
     }
     ngOnDestroy() {

--- a/app/src/app/app.component.ts
+++ b/app/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { OnInit, AfterViewInit, Component, ElementRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, ViewChild, ViewEncapsulation } from '@angular/core';
 import { MatDrawerContainer } from '@angular/material/sidenav';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { getCookie, hasCookie, setCookie } from './util/cookies';
@@ -15,7 +15,7 @@ import { Theme } from './globals';
   styleUrls: ['./app.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
-export class AppComponent implements AfterViewInit, OnInit {
+export class AppComponent implements AfterViewInit {
 
     constructor(private overlayContainer: OverlayContainer,
                 private sidebarService: SidebarService,
@@ -26,7 +26,7 @@ export class AppComponent implements AfterViewInit, OnInit {
         if (hasCookie('theme')) {
             this.setTheme(getCookie('theme'));
         } else {
-            this.setTheme(Theme.LightMode);
+            this.setDefaultTheme();
         }
 
         const routerSubscription = this.router.events.subscribe({
@@ -137,10 +137,6 @@ export class AppComponent implements AfterViewInit, OnInit {
         overlayContainerClasses.remove(Theme.DarkMode, Theme.LightMode);
         overlayContainerClasses.add(this.theme);
         setCookie('theme', theme, 30);
-    }
-
-    ngOnInit(): void {
-      this.setDefaultTheme();
     }
 
     // header hiding with scroll

--- a/app/src/app/app.component.ts
+++ b/app/src/app/app.component.ts
@@ -1,13 +1,13 @@
-import {OnInit, AfterViewInit, Component, ElementRef, ViewChild, ViewEncapsulation} from '@angular/core';
-import {MatDrawerContainer} from '@angular/material/sidenav';
-import {OverlayContainer} from '@angular/cdk/overlay';
-import {getCookie, hasCookie, setCookie} from "./util/cookies";
-import {SidebarService} from './services/sidebar/sidebar.service';
-import {NGXLogger} from 'ngx-logger';
-import {initLogger} from './util/logger';
-import {AuthenticationService} from './services/connectors/authentication/authentication.service';
-import {NavigationEnd, Router} from '@angular/router';
-import {Theme} from './globals';
+import { OnInit, AfterViewInit, Component, ElementRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import { MatDrawerContainer } from '@angular/material/sidenav';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { getCookie, hasCookie, setCookie } from './util/cookies';
+import { SidebarService } from './services/sidebar/sidebar.service';
+import { NGXLogger } from 'ngx-logger';
+import { initLogger } from './util/logger';
+import { AuthenticationService } from './services/connectors/authentication/authentication.service';
+import { NavigationEnd, Router } from '@angular/router';
+import { Theme } from './globals';
 
 @Component({
   selector: 'app-root',
@@ -16,16 +16,6 @@ import {Theme} from './globals';
   encapsulation: ViewEncapsulation.None
 })
 export class AppComponent implements AfterViewInit, OnInit {
-
-    // Drawer container to resize when contents change size
-    @ViewChild(MatDrawerContainer, {static: true}) private container: MatDrawerContainer;
-
-    // Elements for scroll behavior
-    @ViewChild('header', { static: false, read: ElementRef }) private header: ElementRef;
-    @ViewChild('scrollRef', { static: false, read: ElementRef }) private scrollRef: ElementRef;
-
-    public theme = Theme.DarkMode; // sets the default theme?
-    public alertStatus;
 
     constructor(private overlayContainer: OverlayContainer,
                 private sidebarService: SidebarService,
@@ -49,7 +39,7 @@ export class AppComponent implements AfterViewInit, OnInit {
                     });
                 } else if (e instanceof NavigationEnd) {
                     // check user login
-                    let authSubscription = this.authenticationService.getSession().subscribe({
+                    const authSubscription = this.authenticationService.getSession().subscribe({
                         next: (res) => { this.checkStatus(); },
                         complete: () => { authSubscription.unsubscribe(); }
                     });
@@ -61,6 +51,20 @@ export class AppComponent implements AfterViewInit, OnInit {
         initLogger(logger);
     }
 
+    public get sidebarOpened() { return this.sidebarService.opened; }
+
+    // Drawer container to resize when contents change size
+    @ViewChild(MatDrawerContainer, {static: true}) private container: MatDrawerContainer;
+
+    // Elements for scroll behavior
+    @ViewChild('header', { static: false, read: ElementRef }) private header: ElementRef;
+    @ViewChild('scrollRef', { static: false, read: ElementRef }) private scrollRef: ElementRef;
+
+    public theme;
+    public alertStatus;
+
+    public hiddenHeaderPX = 0; // number of px of the header which is hidden
+
     /**
      * Check the account status of the logged in user.
      * If the user's account status is not active, an alert
@@ -68,8 +72,8 @@ export class AppComponent implements AfterViewInit, OnInit {
      */
     public checkStatus(): void {
         if (this.authenticationService.currentUser) {
-            let status = this.authenticationService.currentUser.status;
-            if (status != "active") {
+            const status = this.authenticationService.currentUser.status;
+            if (status != 'active') {
                 this.alertStatus = status;
                 this.logout();
             }
@@ -142,7 +146,7 @@ export class AppComponent implements AfterViewInit, OnInit {
     // header hiding with scroll
     ngAfterViewInit() {
         this.scrollRef.nativeElement.addEventListener('scroll', (e) => this.adjustHeaderPlacement(), true);
-        //to fix rare cases that the page has resized without scroll events triggering, recompute the offset every 5 seconds
+        // to fix rare cases that the page has resized without scroll events triggering, recompute the offset every 5 seconds
       /**
        * The code is using the setInterval() function to call the adjustHeaderPlacement() method every 5
        * seconds. This is likely intended to fix cases where the page has been resized without scroll events being
@@ -153,18 +157,14 @@ export class AppComponent implements AfterViewInit, OnInit {
     ngOnDestroy() {
         this.scrollRef.nativeElement.removeEventListener('scroll', (e) => this.adjustHeaderPlacement(), true);
     }
-
-    public hiddenHeaderPX: number = 0; //number of px of the header which is hidden
     // adjust the header placement
     private adjustHeaderPlacement(): void {
-        let headerHeight = this.header.nativeElement.offsetHeight;
+        const headerHeight = this.header.nativeElement.offsetHeight;
         // constrain amount of hidden to bounds, round up because decimal scroll causes flicker
-        this.hiddenHeaderPX = Math.floor(Math.min(Math.max(0, this.scrollRef.nativeElement.scrollTop/2), headerHeight));
+        this.hiddenHeaderPX = Math.floor(Math.min(Math.max(0, this.scrollRef.nativeElement.scrollTop / 2), headerHeight));
     }
     // scroll to the top of the main content
     public scrollToTop(): void {
-        this.scrollRef.nativeElement.scroll({top: 0, behavior: "smooth"});
+        this.scrollRef.nativeElement.scroll({top: 0, behavior: 'smooth'});
     }
-
-    public get sidebarOpened() { return this.sidebarService.opened; }
 }

--- a/app/src/app/globals.ts
+++ b/app/src/app/globals.ts
@@ -1,0 +1,4 @@
+export const Theme = {
+  LightMode: 'light',
+  DarkMode: 'dark'
+};

--- a/app/tslint.json
+++ b/app/tslint.json
@@ -118,7 +118,8 @@
         "check-operator",
         "check-separator",
         "check-type",
-        "check-typecast"
+        "check-typecast",
+        "check-module"
       ]
     },
     "component-class-suffix": true,


### PR DESCRIPTION
# Summary of Changes:

- Closes #242 
    - When the user initially opens Workbench, the theme will be set based on the user's OS/browser settings, rather than always setting it to light mode. 
    - Details in Issue comment [here](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/issues/242#issuecomment-1363981583).

- Added TSLint rule `{ "whitespace": { "options": [ "check-module ] }` to enforce spaces between curly brackets in the import statements.
    - _e.g._, Before: 
    ```
    import {Theme} from './globals';
    ```
    After:
    ```
    import { Theme } from './globals';
    ```