### PR TITLE
427 revoked objects should not be editable

### DIFF
--- a/app/src/app/components/toolbar/toolbar.component.ts
+++ b/app/src/app/components/toolbar/toolbar.component.ts
@@ -17,17 +17,26 @@ export class ToolbarComponent implements OnInit {
     @Output() public onToggleSidebar = new EventEmitter();
     @Output() public onScrollTop = new EventEmitter();
     @ViewChild('saveValidation') saveValidation: PopoverContentComponent;
-    
+
     public validationData: ValidationData = null;
+    public revoked = false;
 
     public get editing(): boolean { return this.editorService.editing; }
-    public get editable(): boolean { return this.editorService.editable; }
+    public get editable(): boolean { return this.editorService.editable && !this.revoked; }
     public get hasRelationships(): boolean { return this.editorService.hasRelationships; }
     public get deletable(): boolean { return this.editorService.deletable && this.authenticationService.canDelete(); }
 
     public get isLoggedIn(): boolean { return this.authenticationService.isLoggedIn; }
 
-    constructor(private sidebarService: SidebarService, private editorService: EditorService, private authenticationService: AuthenticationService) {}
+    constructor(private sidebarService: SidebarService,
+                private editorService: EditorService,
+                private authenticationService: AuthenticationService) {
+
+      // subscribe to the revoked$ observable and update the element whenever the value changes
+      this.editorService.revoked$.subscribe(value => {
+        this.revoked = value;
+      });
+    }
 
     ngOnInit() {
         // intentionally left blank
@@ -48,17 +57,17 @@ export class ToolbarComponent implements OnInit {
     public delete() {
         this.editorService.onDelete.emit();
     }
-    
+
     // emit a toggle theme event
     public emitToggleTheme() {
         this.onToggleTheme.emit();
     }
     //toggle sidebar
-    public toggleSidebar() { 
+    public toggleSidebar() {
         this.sidebarService.opened = !this.sidebarService.opened;
     }
     // emit scroll to top event
-    public emitScrollTop() { 
+    public emitScrollTop() {
         this.onScrollTop.emit();
     }
 

--- a/app/src/app/views/stix/group/group-view/group-view.component.ts
+++ b/app/src/app/views/stix/group/group-view/group-view.component.ts
@@ -4,6 +4,8 @@ import { StixViewPage } from '../../stix-view-page';
 import { Relationship } from 'src/app/classes/stix/relationship';
 import { AuthenticationService } from 'src/app/services/connectors/authentication/authentication.service';
 import { RestApiConnectorService } from 'src/app/services/connectors/rest-api/rest-api-connector.service';
+import { EditorService } from 'src/app/services/editor/editor.service';
+import { StixObject } from 'src/app/classes/stix/stix-object';
 
 @Component({
     selector: 'app-group-view',
@@ -16,7 +18,9 @@ export class GroupViewComponent extends StixViewPage implements OnInit {
     public relationships_techniques: Relationship[] = [];
     public relationships_software: Relationship[] = [];
 
-    constructor(authenticationService: AuthenticationService, private restApiConnector: RestApiConnectorService) {
+    constructor(authenticationService: AuthenticationService,
+                private restApiConnector: RestApiConnectorService,
+                private editorService: EditorService) {
         super(authenticationService);
     }
 
@@ -24,5 +28,17 @@ export class GroupViewComponent extends StixViewPage implements OnInit {
         if (this.group.firstInitialized) {
             this.group.initializeWithDefaultMarkingDefinitions(this.restApiConnector);
         }
+        /**
+         * Whenever the view is initialized, the `revoked` property on EditorService must be updated to match the
+         * `revoked` property of whichever STIX object is currently in view. When EditorService receives this update, it
+         * notifies ToolbarComponent which happens to be subscribed to the revoked$ Subject (a type of Observable) in
+         * EditorService. ToolbarComponent thus sets its copy of `revoked` to the same value of `revoked` from the
+         * aforementioned STIX object. ToolbarComponent has a boolean property, `editable` that can only be true if
+         * `revoked` is false.
+         *
+         * TL;DR the following call to editorService.updateRevoked is necessary to ensure that the edit toolbar is not
+         * shown when the object in view is revoked.
+         */
+        this.editorService.updateRevoked((this.config.object as StixObject).revoked);
     }
 }

--- a/app/src/app/views/stix/matrix/matrix-view/matrix-view.component.ts
+++ b/app/src/app/views/stix/matrix/matrix-view/matrix-view.component.ts
@@ -4,6 +4,7 @@ import { StixViewPage } from '../../stix-view-page';
 import { RestApiConnectorService } from 'src/app/services/connectors/rest-api/rest-api-connector.service';
 import { StixObject } from 'src/app/classes/stix/stix-object';
 import { AuthenticationService } from 'src/app/services/connectors/authentication/authentication.service';
+import { EditorService } from 'src/app/services/editor/editor.service';
 
 @Component({
     selector: 'app-matrix-view',
@@ -15,7 +16,9 @@ export class MatrixViewComponent extends StixViewPage implements OnInit {
 
     public get matrix(): Matrix { return this.config.object as Matrix; }
 
-    constructor(private restAPIConnectorService: RestApiConnectorService, authenticationService: AuthenticationService) {
+    constructor(private restAPIConnectorService: RestApiConnectorService,
+                authenticationService: AuthenticationService,
+                private editorService: EditorService) {
         super(authenticationService);
     }
 
@@ -26,10 +29,22 @@ export class MatrixViewComponent extends StixViewPage implements OnInit {
                     this.all_tactics = all_tactics.data;
                 },
                 complete: () => { subscription.unsubscribe(); } //prevent memory leaks
-            })
+            });
         }
         if (this.matrix.firstInitialized) {
             this.matrix.initializeWithDefaultMarkingDefinitions(this.restAPIConnectorService);
         }
+        /**
+         * Whenever the view is initialized, the `revoked` property on EditorService must be updated to match the
+         * `revoked` property of whichever STIX object is currently in view. When EditorService receives this update, it
+         * notifies ToolbarComponent which happens to be subscribed to the revoked$ Subject (a type of Observable) in
+         * EditorService. ToolbarComponent thus sets its copy of `revoked` to the same value of `revoked` from the
+         * aforementioned STIX object. ToolbarComponent has a boolean property, `editable` that can only be true if
+         * `revoked` is false.
+         *
+         * TL;DR the following call to editorService.updateRevoked is necessary to ensure that the edit toolbar is not
+         * shown when the object in view is revoked.
+         */
+        this.editorService.updateRevoked((this.config.object as StixObject).revoked);
     }
 }

--- a/app/src/app/views/stix/mitigation/mitigation-view/mitigation-view.component.ts
+++ b/app/src/app/views/stix/mitigation/mitigation-view/mitigation-view.component.ts
@@ -4,6 +4,8 @@ import { StixViewPage } from '../../stix-view-page';
 import { Relationship } from 'src/app/classes/stix/relationship';
 import { AuthenticationService } from 'src/app/services/connectors/authentication/authentication.service';
 import { RestApiConnectorService } from 'src/app/services/connectors/rest-api/rest-api-connector.service';
+import { EditorService } from 'src/app/services/editor/editor.service';
+import { StixObject } from "src/app/classes/stix/stix-object";
 
 @Component({
     selector: 'app-mitigation-view',
@@ -16,7 +18,9 @@ export class MitigationViewComponent extends StixViewPage implements OnInit {
 
     public relationships: Relationship[] = [];
 
-    constructor(authenticationService: AuthenticationService, private restApiConnector: RestApiConnectorService) {
+    constructor(authenticationService: AuthenticationService,
+                private restApiConnector: RestApiConnectorService,
+                private editorService: EditorService) {
         super(authenticationService);
     }
 
@@ -24,5 +28,17 @@ export class MitigationViewComponent extends StixViewPage implements OnInit {
         if (this.mitigation.firstInitialized ) {
             this.mitigation.initializeWithDefaultMarkingDefinitions(this.restApiConnector);
         }
+        /**
+         * Whenever the view is initialized, the `revoked` property on EditorService must be updated to match the
+         * `revoked` property of whichever STIX object is currently in view. When EditorService receives this update, it
+         * notifies ToolbarComponent which happens to be subscribed to the revoked$ Subject (a type of Observable) in
+         * EditorService. ToolbarComponent thus sets its copy of `revoked` to the same value of `revoked` from the
+         * aforementioned STIX object. ToolbarComponent has a boolean property, `editable` that can only be true if
+         * `revoked` is false.
+         *
+         * TL;DR the following call to editorService.updateRevoked is necessary to ensure that the edit toolbar is not
+         * shown when the object in view is revoked.
+         */
+        this.editorService.updateRevoked((this.config.object as StixObject).revoked);
     }
 }

--- a/app/src/app/views/stix/software/software-view/software-view.component.ts
+++ b/app/src/app/views/stix/software/software-view/software-view.component.ts
@@ -3,6 +3,8 @@ import { Software } from 'src/app/classes/stix/software';
 import { AuthenticationService } from 'src/app/services/connectors/authentication/authentication.service';
 import { StixViewPage } from '../../stix-view-page';
 import { RestApiConnectorService } from 'src/app/services/connectors/rest-api/rest-api-connector.service';
+import { EditorService } from 'src/app/services/editor/editor.service';
+import { StixObject } from 'src/app/classes/stix/stix-object';
 
 @Component({
     selector: 'app-software-view',
@@ -13,7 +15,9 @@ export class SoftwareViewComponent extends StixViewPage implements OnInit {
     @Output() public onReload = new EventEmitter();
     public get software(): Software { return this.config.object as Software; }
 
-    constructor(authenticationService: AuthenticationService, private restApiConnector: RestApiConnectorService) {
+    constructor(authenticationService: AuthenticationService,
+                private restApiConnector: RestApiConnectorService,
+                private editorService: EditorService) {
         super(authenticationService);
     }
 
@@ -21,6 +25,18 @@ export class SoftwareViewComponent extends StixViewPage implements OnInit {
         if (this.software.firstInitialized ) {
             this.software.initializeWithDefaultMarkingDefinitions(this.restApiConnector);
         }
+        /**
+         * Whenever the view is initialized, the `revoked` property on EditorService must be updated to match the
+         * `revoked` property of whichever STIX object is currently in view. When EditorService receives this update, it
+         * notifies ToolbarComponent which happens to be subscribed to the revoked$ Subject (a type of Observable) in
+         * EditorService. ToolbarComponent thus sets its copy of `revoked` to the same value of `revoked` from the
+         * aforementioned STIX object. ToolbarComponent has a boolean property, `editable` that can only be true if
+         * `revoked` is false.
+         *
+         * TL;DR the following call to editorService.updateRevoked is necessary to ensure that the edit toolbar is not
+         * shown when the object in view is revoked.
+         */
+        this.editorService.updateRevoked((this.config.object as StixObject).revoked);
     }
 
 }

--- a/app/src/app/views/stix/stix-view-page.ts
+++ b/app/src/app/views/stix/stix-view-page.ts
@@ -6,17 +6,17 @@ import { StixDialogComponent } from './stix-dialog/stix-dialog.component';
 
 @Component({template: ''})
 export abstract class StixViewPage {
-    constructor(private authenticationService: AuthenticationService) { }
-
-    //configuration for the view page behavior
-    @Input() public config: StixViewConfig;
-    public get editing(): boolean { return this.config.mode == "edit"; }
+    constructor(private authenticationService: AuthenticationService) {}
+    public get editing(): boolean { return this.config.mode == 'edit'; }
     public get canEdit(): boolean { return this.authenticationService.canEdit(); }
 
-    //outputs to use if config.sidebarControl == "events"
+    // configuration for the view page behavior
+    @Input() public config: StixViewConfig;
+
+    // outputs to use if config.sidebarControl == "events"
     @Output() public onOpenHistory = new EventEmitter();
-    public openHistory():void { this.onOpenHistory.emit(); }
     @Output() public onOpenNotes = new EventEmitter();
+    public openHistory(): void { this.onOpenHistory.emit(); }
     public openNotes(): void { this.onOpenNotes.emit(); }
 }
 
@@ -26,14 +26,14 @@ export interface StixViewConfig {
     *    edit: editing the object
     *    diff: displaying the diff between two STIX objects. If this mode is selected, two StixObjects must be specified in the objects field
     */
-    mode?: "view" | "diff" | "edit";
+    mode?: 'view' | 'diff' | 'edit';
     /* The object to show on the page
      * Note: if mode is diff, pass an array of two objects to diff
      */
-    object: StixObject | StixObject[]
+    object: StixObject | StixObject[];
     /* if true or omitted, show relationships with the object on the page. If false, omit the relationships */
     showRelationships?: boolean;
-    /* is the current page editable? 
+    /* is the current page editable?
      * if true or omitted, include edit elements on the page such as buttons to add a relationship
      * if false, hide such elements
      */
@@ -45,6 +45,6 @@ export interface StixViewConfig {
      * if "events", sidebar-related controls should be passed as an @output event.
      * if "service", use sidebar.service to control the sidebar
      */
-    sidebarControl?: "disable" | "events" | "service"
-    dialog?: MatDialogRef<StixDialogComponent> // reference to the current dialog
+    sidebarControl?: 'disable' | 'events' | 'service';
+    dialog?: MatDialogRef<StixDialogComponent>; // reference to the current dialog
 }

--- a/app/src/app/views/stix/tactic/tactic-view/tactic-view.component.ts
+++ b/app/src/app/views/stix/tactic/tactic-view/tactic-view.component.ts
@@ -4,6 +4,7 @@ import { AuthenticationService } from 'src/app/services/connectors/authenticatio
 import { StixViewPage } from '../../stix-view-page';
 import { RestApiConnectorService } from 'src/app/services/connectors/rest-api/rest-api-connector.service';
 import { StixObject } from 'src/app/classes/stix/stix-object';
+import { EditorService } from 'src/app/services/editor/editor.service';
 
 @Component({
     selector: 'app-tactic-view',
@@ -15,7 +16,9 @@ export class TacticViewComponent extends StixViewPage implements OnInit {
     public get tactic(): Tactic { return this.config.object as Tactic; }
     public techniques: StixObject[] = [];
 
-    constructor(authenticationService: AuthenticationService, private restApiConnector: RestApiConnectorService) {
+    constructor(authenticationService: AuthenticationService,
+                private restApiConnector: RestApiConnectorService,
+                private editorService: EditorService) {
         super(authenticationService);
     }
 
@@ -25,6 +28,18 @@ export class TacticViewComponent extends StixViewPage implements OnInit {
         } else {
             this.getTechniques();
         }
+        /**
+         * Whenever the view is initialized, the `revoked` property on EditorService must be updated to match the
+         * `revoked` property of whichever STIX object is currently in view. When EditorService receives this update, it
+         * notifies ToolbarComponent which happens to be subscribed to the revoked$ Subject (a type of Observable) in
+         * EditorService. ToolbarComponent thus sets its copy of `revoked` to the same value of `revoked` from the
+         * aforementioned STIX object. ToolbarComponent has a boolean property, `editable` that can only be true if
+         * `revoked` is false.
+         *
+         * TL;DR the following call to editorService.updateRevoked is necessary to ensure that the edit toolbar is not
+         * shown when the object in view is revoked.
+         */
+        this.editorService.updateRevoked((this.config.object as StixObject).revoked);
     }
 
     /**

--- a/app/src/app/views/stix/technique/technique-view/technique-view.component.ts
+++ b/app/src/app/views/stix/technique/technique-view/technique-view.component.ts
@@ -3,6 +3,8 @@ import { Technique } from 'src/app/classes/stix/technique';
 import { StixViewPage } from '../../stix-view-page';
 import { AuthenticationService } from 'src/app/services/connectors/authentication/authentication.service';
 import { RestApiConnectorService } from 'src/app/services/connectors/rest-api/rest-api-connector.service';
+import { EditorService } from 'src/app/services/editor/editor.service';
+import { StixObject } from 'src/app/classes/stix/stix-object';
 
 @Component({
     selector: 'app-technique-view',
@@ -14,7 +16,10 @@ export class TechniqueViewComponent extends StixViewPage implements OnInit, Afte
     @Output() public onReload = new EventEmitter();
     public get technique(): Technique { return this.config.object as Technique; }
 
-    constructor(private ref: ChangeDetectorRef, authenticationService: AuthenticationService, private restApiConnector: RestApiConnectorService) {
+    constructor(private ref: ChangeDetectorRef,
+                authenticationService: AuthenticationService,
+                private restApiConnector: RestApiConnectorService,
+                private editorService: EditorService) {
         super(authenticationService);
     }
 
@@ -22,6 +27,18 @@ export class TechniqueViewComponent extends StixViewPage implements OnInit, Afte
         if (this.technique.firstInitialized) {
             this.technique.initializeWithDefaultMarkingDefinitions(this.restApiConnector);
         }
+        /**
+         * Whenever the view is initialized, the `revoked` property on EditorService must be updated to match the
+         * `revoked` property of whichever STIX object is currently in view. When EditorService receives this update, it
+         * notifies ToolbarComponent which happens to be subscribed to the revoked$ Subject (a type of Observable) in
+         * EditorService. ToolbarComponent thus sets its copy of `revoked` to the same value of `revoked` from the
+         * aforementioned STIX object. ToolbarComponent has a boolean property, `editable` that can only be true if
+         * `revoked` is false.
+         *
+         * TL;DR the following call to editorService.updateRevoked is necessary to ensure that the edit toolbar is not
+         * shown when the object in view is revoked.
+         */
+        this.editorService.updateRevoked((this.config.object as StixObject).revoked);
       }
 
     ngAfterContentChecked() {


### PR DESCRIPTION
Closes #427 

# Solution

We don't want object's to be editable if an object _is_ revoked and/or when an object _becomes_ revoked. Components that deal with rendering the editing toolbar must be updated to only render when `revoked` is false.

We can accomplish this with a shared service and a boolean observable called `revoked`. STIX-based components can sync their nested `revoked` values (_i.e._, `this.config.object.revoked`) to the shared service, and components that depend on the `revoked` value (_i.e._, `ToolbarComponent`) can subscribe to the observable. 

![workbench-disable-editing-of-revoked-objects](https://user-images.githubusercontent.com/23294618/213801950-d1684f90-6bc6-46e7-8e33-9e945d4072b2.png)
