### PR TITLE
Fix bug with setting light/dark mode from system/browser default

### DIFF
--- a/app/src/app/app.component.ts
+++ b/app/src/app/app.component.ts
@@ -131,7 +131,12 @@ export class AppComponent implements AfterViewInit {
         // use the addEventListener method of the MediaQueryList object to set up a listener that will be called
         // whenever the light/dark mode setting changes
         mediaQueryList.addEventListener('change', (event) => {
-          this.theme = event.matches ? Theme.DarkMode : Theme.LightMode;
+            if (hasCookie('theme')) {
+                // User has set the theme using the app's toggle button, ignore changes in system/browser mode
+            } else {
+                this.theme = event.matches ? Theme.DarkMode : Theme.LightMode;
+                this.setThemeOnOverlayContainerElement();
+            }
         });
     }
 

--- a/app/src/app/app.component.ts
+++ b/app/src/app/app.component.ts
@@ -126,6 +126,7 @@ export class AppComponent implements AfterViewInit {
         // it is in light mode
         const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
         this.theme = mediaQueryList.matches ? Theme.DarkMode : Theme.LightMode;
+        this.setThemeOnOverlayContainerElement();
 
         // use the addEventListener method of the MediaQueryList object to set up a listener that will be called
         // whenever the light/dark mode setting changes
@@ -137,10 +138,14 @@ export class AppComponent implements AfterViewInit {
     public setTheme(theme: string): void {
         this.logger.log(`Setting theme to ${theme}`);
         this.theme = theme;
-        const overlayContainerClasses = this.overlayContainer.getContainerElement().classList;
-        overlayContainerClasses.remove(Theme.DarkMode, Theme.LightMode);
-        overlayContainerClasses.add(this.theme);
+        this.setThemeOnOverlayContainerElement();
         setCookie('theme', theme, 30);
+    }
+
+    private setThemeOnOverlayContainerElement(): void {
+      const overlayContainerClasses = this.overlayContainer.getContainerElement().classList;
+      overlayContainerClasses.remove(Theme.DarkMode, Theme.LightMode);
+      overlayContainerClasses.add(this.theme);
     }
 
     // header hiding with scroll


### PR DESCRIPTION
Sets the theme class on the overlay container element when using the system/browser default for light/dark mode.

Also ignores changes to the system/browser default after the user clicks the 'toggle theme' button.

closes #436 