### PR TITLE
add documentation for default landing page and collection import

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ These environment properties can be edited under `src/environments`:
 - [src/environments/environment.ts](app/src/environments/environment.ts) is the development environment with configurations for when it is hosted on a local machine or is being actively developed. This is the default environment file used when building the application.
 - [src/environments/environment.prod.ts](app/src/environments/environment.prod.ts) is the production environment for deployment inside of an organization or in cases where the user is not developing the application. When the application is built for production deployments (`ng build --prod`) this environment file is used.
 
+#### Setting the Default Landing Page
+To allow for additional customization, the ATT&CK Workbench enables users to set a default landing page for their instance of Workbench. To set the default landing page:
+- Open up the config file, found at `src/assets/config.ts`.
+- Set the `defaultLandingPage` variable to the url path you want to set as the default landing page
+  - You can set the default to a more general page, such as the tactic list view `"defaultLandingPage": "tactic"`, or to a specific page, such as a certain matrix `"defaultLandingPage": "matrix/x-mitre-matrix--eafc1b4c-5e56-4965-bd4e-66a6a89c88cc"`
+
 #### PKI Certificates
 
 For additional troubleshooting and installation of security certificates for use by ATT&CK Workbench, pleaser refer to [PKI Certificates instructions](docs/certs.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,7 +41,7 @@ There are multiple means through which a collection can be imported. The "import
 
 Users can import the collection in several different ways:
 - *Import from URL*: In cases where the collection has been hosted on the internet, the user may specify the URL of a collection STIX bundle for the application to download.
-<!-- - *Upload from file*: Users can also upload a STIX bundle representing the collection. -->
+- *Upload from file*: Users can upload a STIX bundle representing the collection. You can upload a collection in JSON, CSV, or XLSX format.
 - *Import from collection index*: The user can choose to import collections listed by attached _collection indexes_, which are essentially lists of collections on the internet.
 
 ##### 2. Review Contents


### PR DESCRIPTION
Documentation for collection import, matrix view, and default landing page