### PR TITLE
Fix/467

### DIFF
--- a/app/src/app/components/object-status/object-status.component.ts
+++ b/app/src/app/components/object-status/object-status.component.ts
@@ -63,7 +63,7 @@ export class ObjectStatusComponent implements OnInit {
                     this.objects = data.data;
                     this.object = this.objects.find(object => object.stixID === this.editorService.stixId);
                     if (this.object) {
-                        if (this.object.workflow && this.object.workflow.state) {
+                        if (this.object.workflow?.state) {
                             this.statusControl.setValue(this.object.workflow.state);
                         }
                         this.revoked = this.object.revoked;

--- a/app/src/app/components/object-status/object-status.component.ts
+++ b/app/src/app/components/object-status/object-status.component.ts
@@ -155,30 +155,16 @@ export class ObjectStatusComponent implements OnInit {
                 complete: () => { revokedSubscription.unsubscribe(); }
             });
         } else {
-            // deprecate the 'revoked-by' relationship
-            let revokedRelationships = this.relationships.filter(relationship => relationship.relationship_type == 'revoked-by');
-            for (let relationship of revokedRelationships) {
-                let other_obj: any;
-                if (relationship.source_object.stix.id == this.object.stixID) other_obj = relationship.target_object.stix;
-                else other_obj = relationship.source_object.stix;
-
-                if (!this.isDeprecatedOrRevoked(other_obj)) {
-                    relationship.deprecated = true;
-                    relationship.save(this.restAPIService);
-                }
+            // unrevoke object, deprecate the 'revoked-by' relationship
+            // this is the only case in which a 'revoked-by' relationship is deprecated
+            let revokedRelationship = this.relationships.find(r => r.relationship_type == 'revoked-by' && r.source_ref == this.object.stixID);
+            if (revokedRelationship) {
+                revokedRelationship.deprecated = true;
+                revokedRelationship.save(this.restAPIService);
             }
-            // un-revoke object
             this.object.revoked = false;
             this.save();
         }
-    }
-
-    /**
-     * Check if the given object is deprecated or revoked
-     * @param object source or target object of a relationship
-     */
-    private isDeprecatedOrRevoked(object: any) {
-        return ('x_mitre_deprecated' in object && object.x_mitre_deprecated) || ('revoked' in object && object.revoked);
     }
 
     /**
@@ -225,7 +211,8 @@ export class ObjectStatusComponent implements OnInit {
         
                 // update relationships with the object
                 for (let relationship of this.relationships) {
-                    if (!relationship.deprecated && relationship.relationship_type != 'subtechnique-of') {
+                    // do not deprecate 'subtechnique-of' or 'revoked-by' relationships
+                    if (!relationship.deprecated && !['subtechnique-of', 'revoked-by'].includes(relationship.relationship_type)) {
                         relationship.deprecated = true;
                         saves.push(relationship.save(this.restAPIService));
                     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,8 +34,11 @@
 
 ## Changes Staged on Develop
 
-#### New Features in x.x.x
--   Added ability to create and edit Asset objects.
+#### New Features in 2.1.0
+-   Added the ability to create, view, and edit Asset objects.
+
+#### Fixes in 2.1.0
+-   Fixed an issue where revoking or deprecating an object would deprecate all `revoked-by` relationships with the object. See [#467](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/issues/467).
 
 ## 21 September 2023
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,7 +38,7 @@
 -   Added the ability to create, view, and edit Asset objects.
 
 #### Fixes in 2.1.0
--   Fixed an issue where revoking or deprecating an object would deprecate all `revoked-by` relationships with the object. See [#467](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/issues/467).
+-   Fixed an issue where revoking or deprecating an object would deprecate all `revoked-by` relationships with the object. See [frontend#467](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/issues/467).
 
 ## 21 September 2023
 


### PR DESCRIPTION
Fixes an issue where revoking or deprecating an object would deprecate all `revoked-by` relationships with that object. The only case in which a `revoked-by` relationship will be marked as deprecated is if the source object has been “un-revoked”.