### PR TITLE
Fix first seen/last seen date parsing

### DIFF
--- a/app/src/app/components/stix/datepicker-property/datepicker-property.component.ts
+++ b/app/src/app/components/stix/datepicker-property/datepicker-property.component.ts
@@ -47,7 +47,7 @@ export class DatepickerPropertyComponent {
     public get formatHint() { return DATE_FORMATS.parse.dateInput; }
     public get date() { // get date in view display format (i.e. January 2022)
         if (this.config.object[this.config.field]) {
-            return moment(this.config.object[this.config.field]).format('MMMM YYYY');
+            return moment.utc(this.config.object[this.config.field]).format('MMMM YYYY');
         }
         return null;
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,7 @@
 
 #### Fixes in 2.1.0
 -   Fixed an issue where revoking or deprecating an object would deprecate all `revoked-by` relationships with the object. See [frontend#467](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/issues/467).
+-   Fixed an issue where first/last seen Campaign dates were parsed in local time, causing the dates to be displayed incorrectly in certain timezones. See [frontend#508](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/pull/508).
 
 ## 21 September 2023
 


### PR DESCRIPTION
Parses dates in UTC rather than local mode to display the same output for all timezones.