### PR TITLE
added 'includeDeprecatedObjects' to not filter out deprecated objects

### DIFF
--- a/app/src/app/components/reference-edit-dialog/reference-edit-dialog.component.html
+++ b/app/src/app/components/reference-edit-dialog/reference-edit-dialog.component.html
@@ -204,7 +204,8 @@
                     <app-stix-list (onRowAction)="close()" [config]="{
                         stixObjects: stixObjects,
                         clickBehavior: 'linkToObjectPage',
-                        showControls: false
+                        showControls: false,
+                        includeDeprecatedObjects: true
                     }"></app-stix-list>
                 </ng-container>
                 <ng-container *ngIf="relationships.length > 0">
@@ -213,7 +214,8 @@
                         stixObjects: relationships,
                         type: 'relationship',
                         clickBehavior: 'dialog',
-                        showControls: false
+                        showControls: false,
+                        includeDeprecatedObjects: true
                     }"></app-stix-list>
                 </ng-container>
             </ng-template>

--- a/app/src/app/components/stix/stix-list/stix-list.component.ts
+++ b/app/src/app/components/stix/stix-list/stix-list.component.ts
@@ -746,7 +746,7 @@ export class StixListComponent implements OnInit, AfterViewInit, OnDestroy {
                 // filter by deprecation status
                 if (exclusiveDeprecated) {
                     filtered = filtered.filter((obj:any)=> obj.deprecated)
-                } else if (deprecated) {
+                } else if (deprecated || this.config.includeDeprecatedObjects) {
                     filtered = filtered.filter((obj: any) => obj || obj.deprecated);
                 } else {
                     filtered = filtered.filter((obj: any) => !obj.deprecated);
@@ -957,6 +957,8 @@ export interface StixListConfig {
      *  the list of STIX objects is provided in the 'stixObjects' configuration
      */
     showDeprecatedFilter?: boolean;
+    /** include deprecated objects in list of STIX objects, default false*/
+    includeDeprecatedObjects?: boolean;
     /** default ['state','workflow_status'], if decides which filters to show */
     filterList?: Array<filter_types>;
     /** default: false, if false hides the user search in the filters*/


### PR DESCRIPTION
Currently, when opening a source in the Reference Manager, deprecated objects aren't listed under "Objects citing this reference". As you can see in the image, the bottom navigation shows there are 3 objects, while only two are listed. 

![image](https://github.com/user-attachments/assets/62bf5fc0-eba1-406e-93f7-1f94a402082a)

This change adds a new property called `includeDeprecatedObjects` that can be added to the stix-list component to indicate whether or not deprecated objects should be included in the list.
