### PR TITLE
Automatic synchronization of tactics between parent and sub-techniques

### DIFF
--- a/app/src/app/classes/stix/technique.ts
+++ b/app/src/app/classes/stix/technique.ts
@@ -1,13 +1,14 @@
-import { forkJoin, Observable } from "rxjs";
-import { map, switchMap } from "rxjs/operators";
+import { forkJoin, Observable, of } from "rxjs";
+import { concatMap, map, shareReplay, switchMap } from "rxjs/operators";
 import { RestApiConnectorService } from "src/app/services/connectors/rest-api/rest-api-connector.service";
 import { ValidationData } from "../serializable";
 import { StixObject } from "./stix-object";
 import { logger } from "../../utils/logger";
+import { Relationship } from "./relationship";
 
 export class Technique extends StixObject {
     public name: string = "";
-    public kill_chain_phases: any = [];
+    public kill_chain_phases: any[] = [];
     public domains: string[] = [];
     public platforms: string[] = [];
     public detection: string = "";
@@ -42,7 +43,7 @@ export class Technique extends StixObject {
     }
 
     public get tactics(): string[] { return this.kill_chain_phases.map(tactic => tactic.phase_name); }
-    public set tactics(values) {
+    public set tactics(values: any[]) {
         let killChainPhases = [];
         for (let i in values) {
             let phaseName = values[i][0];
@@ -296,16 +297,29 @@ export class Technique extends StixObject {
                     super_of: restAPIService.getRelatedTo({targetRef: this.stixID, relationshipType: "subtechnique-of"})
                 }).pipe(
                     map(relationships => {
+                        // validate technique <-> sub-technique conversion
                         if (this.is_subtechnique && relationships.super_of.data.length > 0) validationResult.errors.push({
                             "field": "is_subtechnique",
                             "result": "error",
                             "message": "technique with sub-techniques cannot be converted to sub-technique"
-                        })
+                        });
                         if (!this.is_subtechnique && relationships.sub_of.data.length > 0) validationResult.errors.push({
                             "field": "is_subtechnique",
                             "result": "error",
                             "message": "sub-technique with parent cannot be converted to technique"
-                        })
+                        });
+
+                        // added tactic syncing information
+                        if ((this.is_subtechnique && relationships.sub_of.data.length > 0)
+                            || (!this.is_subtechnique && relationships.super_of.data.length > 0)) {
+                            // sub-technique with assigned parent or parent with sub-techniques
+                            validationResult.info.push({
+                                "field": "tactics",
+                                "result": "info",
+                                "message": "sub-technique tactics will sync with parent technique"
+                            })
+                        }
+
                         return validationResult;
                     })
                 )
@@ -313,17 +327,142 @@ export class Technique extends StixObject {
         );
     }
 
+    private updateParentRelationship(restApiService: RestApiConnectorService): Observable<any> {
+        if (this.is_subtechnique && this.parentTechnique) {
+            // retrieve 'subtechnique-of' relationship, if any
+            return restApiService.getRelatedTo({sourceRef: this.stixID, relationshipType: "subtechnique-of"}).pipe(
+                switchMap(r => {
+                    let createRelationship = function(source, target): Relationship {
+                        // function to create a new 'subtechnique-of' relationship
+                        // with the given source and target object
+                        let newRelationship = new Relationship();
+                        newRelationship.relationship_type = 'subtechnique-of';
+                        newRelationship.set_source_object(source, restApiService);
+                        newRelationship.set_target_object(target, restApiService);
+                        return newRelationship;
+                    };
+
+                    let relationshipUpdates = [];
+
+                    if (r.data.length > 0 && r.data[0]) {
+                        // relationship exists, check if parent has changed
+                        let relationship = r.data[0] as Relationship;
+                        if (relationship.target_ref !== this.parentTechnique.stixID) {
+                            // parent technique changed, revoke previous 'subtechnique-of'
+                            // relationship and create a new one
+                            relationship.revoked = true;
+                            relationshipUpdates.push(relationship.save(restApiService));
+                            const newRelationship = createRelationship(this, this.parentTechnique);
+                            relationshipUpdates.push(newRelationship.save(restApiService));
+                        } // otherwise parent has not changed, do nothing
+                    } else {
+                        // 'subtechnique-of' relationship does not exist, create a new one
+                        const newRelationship = createRelationship(this, this.parentTechnique);
+                        relationshipUpdates.push(newRelationship.save(restApiService));
+                    }
+
+                    return forkJoin(relationshipUpdates.length ? relationshipUpdates : [of(null)])
+                })
+            );
+        } else {
+            return of(null);
+        }
+    }
+
+    private syncTacticsWithParentOrSubs(restApiService: RestApiConnectorService): Observable<any> {
+        // case: sub-technique with assigned parent technique
+        if (this.is_subtechnique && this.parentTechnique) {
+            // sync this sub-technique's tactics with its parent
+            return restApiService.getRelatedTo({sourceRef: this.stixID, relationshipType: 'subtechnique-of'}).pipe(
+                switchMap(r => {
+                    if (r.data.length > 0) {
+                        let relationship = r.data[0] as Relationship;
+                        return restApiService.getTechnique(relationship.target_ref, null, "latest").pipe(
+                            switchMap(parentData => {
+                                let parent: Technique = parentData?.[0];
+                                if (parent && !this.killChainPhasesSynced(parent.kill_chain_phases, this.kill_chain_phases)) {
+                                    // this sub-technique's tactics are not synced with its parent
+                                    let parentTactics = parent.kill_chain_phases.map(kcp => [kcp.phase_name, this.killChainMap[kcp.kill_chain_name]])
+                                    this.tactics = parentTactics;
+                                    // the saving of this update occurs in the save() function and is not needed here
+                                }
+                                return of(null);
+                            })
+                        )
+                    }
+                    return of(null);
+                })
+            );
+        }
+
+        // case: sub-technique without assigned parent
+        else if (this.is_subtechnique && !this.parentTechnique) return of(null);
+
+        // case: parent technique, need to check if parent has sub-techniques
+        else {
+            // get any related "subtechnique-of" relationships, where the parent is this object (target_ref)
+            return restApiService.getRelatedTo({targetRef: this.stixID, relationshipType: 'subtechnique-of'}).pipe(
+                switchMap(r => {
+                    // case: parent technique with sub-techniques
+                    if (r.data.length > 0) {
+                        // sync all sub-techniques' tactics with this object's tactics
+                        const subTechniqueUpdates = r.data.map(sr => {
+                            let subRelationship = sr as Relationship;
+                            // get latest sub-technique object from relationship (source_ref)
+                            return restApiService.getTechnique(subRelationship.source_ref, null, "latest").pipe(
+                                switchMap(subData => {
+                                    let subtechnique: Technique = subData?.[0];
+                                    if (subtechnique && !this.killChainPhasesSynced(subtechnique.kill_chain_phases, this.kill_chain_phases)) {
+                                        // sub-technique tactics are not synced with this parent
+                                        let parentTactics = this.kill_chain_phases.map(kcp => [kcp.phase_name, this.killChainMap[kcp.kill_chain_name]])
+                                        subtechnique.tactics = parentTactics;
+                                        // NOTE: do not use subtechnique.save(restApiService)
+                                        return restApiService.postTechnique(subtechnique);
+                                    }
+                                    // tactics already synced
+                                    return of(null);
+                                })
+                            )
+                        })
+                        return forkJoin(subTechniqueUpdates)
+                    }
+                    // case: parent technique with no sub-techniques
+                    return of(null);
+                })
+            )
+        }
+    }
+
+    private killChainPhasesSynced(tacticsA: any[], tacticsB: any[]) {
+        if (tacticsA.length !== tacticsB.length) return false;
+
+        // sort kcps to ensure a consistent order for comparison
+        const sortedA = [...tacticsA].sort((a, b) => a.phase_name.localeCompare(b.phase_name));
+        const sortedB = [...tacticsB].sort((a, b) => a.phase_name.localeCompare(b.phase_name));
+
+        return sortedA.every((kcpA, i) => {
+            let kcpB = sortedB[i];
+            return kcpA.phase_name == kcpB.phase_name && kcpA.kill_chain_name == kcpB.kill_chain_name;
+        })
+    }
+
     /**
      * Save the current state of the STIX object in the database. Update the current object from the response
      * @param restAPIService [RestApiConnectorService] the service to perform the POST/PUT through
      * @returns {Observable} of the post
      */
-    public save(restAPIService: RestApiConnectorService): Observable<Technique> {
-        let postObservable = restAPIService.postTechnique(this);
+    public save(restApiService: RestApiConnectorService): Observable<Technique> {
+        const postObservable = this.updateParentRelationship(restApiService).pipe(
+            concatMap(() => this.syncTacticsWithParentOrSubs(restApiService)),
+            concatMap(() => restApiService.postTechnique(this)),
+            shareReplay(1) // share the result and ensure only the last POST result is emitted
+        );
+
         let subscription = postObservable.subscribe({
             next: (result) => { this.deserialize(result.serialize()); },
             complete: () => { subscription.unsubscribe(); }
         });
+
         return postObservable;
     }
 

--- a/app/src/app/components/save-dialog/save-dialog.component.html
+++ b/app/src/app/components/save-dialog/save-dialog.component.html
@@ -3,14 +3,7 @@
         <div class="column validation">
             <h3>Validation</h3>
             <div *ngIf="validation else validating">
-                <app-validation-results [validation]="validation"></app-validation-results>
-                <mat-list class="patch-warning" *ngIf="config.patchID">
-                    <mat-list-item class="validation-item warning">
-                        <mat-icon matListItemIcon>warning</mat-icon>
-                        <div matListItemLine>ATT&CK ID changed</div>
-                        <div matListItemLine>knowledge base patches will be determined in next step</div>
-                    </mat-list-item>
-                </mat-list>
+                <app-validation-results [validation]="validation" [patchId]="config.patchId"></app-validation-results>
             </div>
             <ng-template #validating>
                 <app-loading-overlay></app-loading-overlay>

--- a/app/src/app/components/save-dialog/save-dialog.component.scss
+++ b/app/src/app/components/save-dialog/save-dialog.component.scss
@@ -36,9 +36,6 @@
             margin-bottom: 0px;
         }
     }
-    .validation-item.warning {
-		color: color(warn);
-    }
     .column + .column {
         padding-left: 16px;
         .dark & { border-left: 1px solid border-color(dark); }

--- a/app/src/app/components/save-dialog/save-dialog.component.ts
+++ b/app/src/app/components/save-dialog/save-dialog.component.ts
@@ -126,47 +126,7 @@ export class SaveDialogComponent implements OnInit {
     }
 
     private saveObject() {
-        return this.config.object.save(this.restApiService).pipe( // save this object
-            map(result => {
-                if (result.attackType !== 'technique') return result;
-                let technique = this.config.object as Technique;
-
-                if (technique.is_subtechnique && technique.parentTechnique) {
-                    // retrieve 'subtechnique-of' relationship, if any
-                    const sub$ = this.restApiService.getRelatedTo({sourceRef: technique.stixID, relationshipType: "subtechnique-of"})
-                    const sub = sub$.subscribe({
-                        next: (r) => {
-                            let createRelationship = function(source, target, restApiService): Relationship {
-                                // create a new 'subtechnique-of' relationship with the given source and target object
-                                let newRelationship = new Relationship();
-                                newRelationship.relationship_type = 'subtechnique-of';
-                                newRelationship.set_source_object(source, restApiService);
-                                newRelationship.set_target_object(target, restApiService);
-                                return newRelationship;
-                            }
-
-                            if (r.data.length > 0 && r.data[0]) {
-                                // relationship exists, check if parent has changed
-                                let relationship = r.data[0] as Relationship;
-                                if (relationship.target_ref !== technique.parentTechnique.stixID) {
-                                    // parent technique has changed, revoke previous 'subtechnique-of' relationship and create a new one
-                                    relationship.revoked = true;
-                                    relationship.save(this.restApiService);
-                                    const newRelationship = createRelationship(technique, technique.parentTechnique, this.restApiService);
-                                    newRelationship.save(this.restApiService);
-                                } // otherwise parent has not changed, do nothing
-                            } else {
-                                // 'subtechnique-of' relationship does not exist, create a new one
-                                const newRelationship = createRelationship(technique, technique.parentTechnique, this.restApiService);
-                                newRelationship.save(this.restApiService);
-                            }
-                        },
-                        complete: () => sub.unsubscribe()
-                    });
-                }
-                return of(result);
-            })
-        );
+        return this.config.object.save(this.restApiService); // save this object
     }
 
     /**

--- a/app/src/app/components/save-dialog/save-dialog.component.ts
+++ b/app/src/app/components/save-dialog/save-dialog.component.ts
@@ -60,7 +60,7 @@ export class SaveDialogComponent implements OnInit {
         let objSubscription = this.restApiService.getAllObjects({deserialize: true}).subscribe({
             next: (results) => {
                 // find objects with a link to the previous ID
-                let objLink = `(LinkById: ${this.config.patchID})`;
+                let objLink = `(LinkById: ${this.config.patchId})`;
                 results.data.forEach(x => {
                     if ((x.description && x.description.indexOf(objLink) !== -1) || ("detection" in x && x.detection && x.detection.indexOf(objLink) !== -1)) {
                             this.patch_objects.push(x);
@@ -80,7 +80,7 @@ export class SaveDialogComponent implements OnInit {
         let saves = [];
         for (let obj of this.patch_objects) {
             // replace LinkById references with the new ATT&CK ID
-            let regex = new RegExp(`\\(LinkById: (${this.config.patchID})\\)`, "gmu");
+            let regex = new RegExp(`\\(LinkById: (${this.config.patchId})\\)`, "gmu");
             obj.description = obj.description.replace(regex, `(LinkById: ${this.config.object.attackID})`);
             if (obj.hasOwnProperty("detection") && obj.detection) {
                 obj.detection = obj.detection.replace(regex, `(LinkById: ${this.config.object.attackID})`);
@@ -101,7 +101,7 @@ export class SaveDialogComponent implements OnInit {
      */
     public saveCurrentVersion() {
         this.config.object.workflow = this.newState ? {state: this.newState } : undefined;
-        if (this.config.patchID) this.parse_patches();
+        if (this.config.patchId) this.parse_patches();
         else this.save();
     }
 
@@ -111,7 +111,7 @@ export class SaveDialogComponent implements OnInit {
      public saveNextMinorVersion() {
         this.config.object.version = new VersionNumber(this.nextMinorVersion);
         this.config.object.workflow = this.newState ? {state: this.newState } : undefined;
-        if (this.config.patchID) this.parse_patches();
+        if (this.config.patchId) this.parse_patches();
         else this.save();
     }
 
@@ -121,7 +121,7 @@ export class SaveDialogComponent implements OnInit {
     public saveNextMajorVersion() {
         this.config.object.version = new VersionNumber(this.nextMajorVersion);
         this.config.object.workflow = this.newState ? {state: this.newState } : undefined;
-        if (this.config.patchID) this.parse_patches();
+        if (this.config.patchId) this.parse_patches();
         else this.save();
     }
 
@@ -149,6 +149,6 @@ export class SaveDialogComponent implements OnInit {
 
 export interface SaveDialogConfig {
     object: StixObject;
-    patchID?: string; // previous object ID to patch in LinkByID tags
+    patchId?: string; // previous object ID to patch in LinkByID tags
     versionAlreadyIncremented: boolean;
 }

--- a/app/src/app/components/stix/list-property/list-edit/list-edit.component.html
+++ b/app/src/app/components/stix/list-property/list-edit/list-edit.component.html
@@ -37,16 +37,16 @@
 		[class.disabled]="config.disabled || !dataLoaded"
 		(click)="openStixList()"
         (keydown)="openStixList()"
-		[matTooltip]="config.disabled ? 'a valid domain must be selected first' : null">
+		[matTooltip]="config.disabled ? (config.object.is_subtechnique ? 'sub-technique tactics are automatically synced with its parent' : 'a valid domain must be selected first') : null">
 		<div class="content">
 			<mat-chip-listbox #stixChipList [required]="config.required ? config.required : false" [disabled]="!dataLoaded || config.disabled" (blur)="onBlur()">
 				<mat-chip *ngFor="let value of selectedValues()" [removable]="false">{{value}}</mat-chip>
 			</mat-chip-listbox>
-			<span matIconSuffix *ngIf="!dataLoaded && config.label === 'parent technique'" class="loading-label">
+			<span matIconSuffix *ngIf="!dataLoaded && config.field === 'parentTechnique'" class="loading-label">
 				<mat-spinner class="spinner" diameter="20"></mat-spinner>
 			</span>
-			<span matIconSuffix *ngIf="!(!dataLoaded && config.label === 'parent technique')">
-				<mat-icon aria-hidden="false" aria-label="open" class="icon">open_in_new</mat-icon>
+			<span matIconSuffix *ngIf="dataLoaded">
+				<mat-icon aria-hidden="false" aria-label="open" class="icon" [class.disabled]="config.disabled">open_in_new</mat-icon>
 			</span>
 		</div>
         <span class="labelled-box-label">{{config.label? config.label : config.field}}</span>

--- a/app/src/app/components/stix/list-property/list-edit/list-edit.component.html
+++ b/app/src/app/components/stix/list-property/list-edit/list-edit.component.html
@@ -37,7 +37,7 @@
 		[class.disabled]="config.disabled || !dataLoaded"
 		(click)="openStixList()"
         (keydown)="openStixList()"
-		[matTooltip]="config.disabled ? (config.object.is_subtechnique ? 'sub-technique tactics are automatically synced with its parent' : 'a valid domain must be selected first') : null">
+		[matTooltip]="config.disabled ? (config.object.is_subtechnique ? 'sub-technique tactics are automatically synced with its parent tactics' : 'a valid domain must be selected first') : null">
 		<div class="content">
 			<mat-chip-listbox #stixChipList [required]="config.required ? config.required : false" [disabled]="!dataLoaded || config.disabled" (blur)="onBlur()">
 				<mat-chip *ngFor="let value of selectedValues()" [removable]="false">{{value}}</mat-chip>
@@ -45,8 +45,8 @@
 			<span matIconSuffix *ngIf="!dataLoaded && config.field === 'parentTechnique'" class="loading-label">
 				<mat-spinner class="spinner" diameter="20"></mat-spinner>
 			</span>
-			<span matIconSuffix *ngIf="dataLoaded">
-				<mat-icon aria-hidden="false" aria-label="open" class="icon" [class.disabled]="config.disabled">open_in_new</mat-icon>
+			<span matIconSuffix *ngIf="dataLoaded && !config.disabled">
+				<mat-icon aria-hidden="false" aria-label="open" class="icon">open_in_new</mat-icon>
 			</span>
 		</div>
         <span class="labelled-box-label">{{config.label? config.label : config.field}}</span>

--- a/app/src/app/components/stix/list-property/list-edit/list-edit.component.scss
+++ b/app/src/app/components/stix/list-property/list-edit/list-edit.component.scss
@@ -26,7 +26,17 @@
     input { font-size: 14px; }
 
     // stix list object selection dialog
-    .icon { float: right; }
+    .icon {
+        float: right;
+        &.disabled {
+            .dark & {
+                color: border-color(dark) !important;
+            }
+            .light & {
+                color: border-color(light) !important;
+            }
+        }
+    }
     .stix-select {
         &:not(.disabled) { cursor: pointer; }
     }

--- a/app/src/app/components/stix/list-property/list-edit/list-edit.component.scss
+++ b/app/src/app/components/stix/list-property/list-edit/list-edit.component.scss
@@ -30,10 +30,10 @@
         float: right;
         &.disabled {
             .dark & {
-                color: border-color(dark) !important;
+                color: on-color-deemphasis(light) !important;
             }
             .light & {
-                color: border-color(light) !important;
+                color: on-color-deemphasis(dark) !important;
             }
         }
     }

--- a/app/src/app/components/stix/list-property/list-edit/list-edit.component.ts
+++ b/app/src/app/components/stix/list-property/list-edit/list-edit.component.ts
@@ -321,6 +321,7 @@ export class ListEditComponent implements OnInit, AfterContentChecked {
         let subscription = dialogRef.afterClosed().subscribe({
             next: (result) => {
                 if (result) {
+                    // update object tactic list
                     let tacticShortnames = this.select.selected.map(id => this.stixIDToShortname(id));
                     this.config.object[this.config.field] = tacticShortnames;
 
@@ -363,6 +364,9 @@ export class ListEditComponent implements OnInit, AfterContentChecked {
                         })
                         this.config.object['tactics'] = parentTactics;
                         // once saved, any irrelevant tactic-specific fields will be removed from the sub-technique
+                    } else {
+                        // parent removed, clear tactics list
+                        this.config.object['tactics'] = [];
                     }
                 } else { // user cancelled
                     this.select = selectCopy; // reset selection

--- a/app/src/app/components/stix/list-property/list-edit/list-edit.component.ts
+++ b/app/src/app/components/stix/list-property/list-edit/list-edit.component.ts
@@ -337,6 +337,11 @@ export class ListEditComponent implements OnInit, AfterContentChecked {
     }
 
     /** Open parent technique list */
+    private killChainMap = {
+        "mitre-attack": "enterprise-attack",
+        "mitre-mobile-attack": "mobile-attack",
+        "mitre-ics-attack": "ics-attack"
+    }
     public openParentTechniqueList(): void {
         // check if parent techniques have been loaded, if not, do nothing
         if (this.config.label === 'parent technique' && !this.dataLoaded) return;
@@ -351,6 +356,14 @@ export class ListEditComponent implements OnInit, AfterContentChecked {
                     let allObjects = this.allObjects as Technique[];
                     let selection = this.select.selected.length > 0 ? allObjects.find(t => t.stixID === this.select.selected[0]) : null;
                     this.config.object[this.config.field] = selection;
+                    if (selection) {
+                        // sync sub-technique tactics with parent
+                        let parentTactics = selection.kill_chain_phases.map(kcp => {
+                            return [kcp.phase_name, this.killChainMap[kcp.kill_chain_name]]
+                        })
+                        this.config.object['tactics'] = parentTactics;
+                        // once saved, any irrelevant tactic-specific fields will be removed from the sub-technique
+                    }
                 } else { // user cancelled
                     this.select = selectCopy; // reset selection
                 }

--- a/app/src/app/components/validation-results/validation-results.component.html
+++ b/app/src/app/components/validation-results/validation-results.component.html
@@ -11,6 +11,11 @@
         <mat-icon matListItemIcon>warning</mat-icon>
         <div matListItemLine>{{warning.message}}</div>
     </mat-list-item>
+    <mat-list-item class="validation-item warning" *ngIf="patchId">
+        <mat-icon matListItemIcon>warning</mat-icon>
+        <div matListItemLine>ATT&CK ID changed</div>
+        <div matListItemLine>knowledge base patches will be determined in next step</div>
+    </mat-list-item>
     <mat-list-item class="validation-item info" *ngFor="let info of validation.info">
         <mat-icon matListItemIcon>info</mat-icon>
         <div matListItemLine>{{info.message}}</div>

--- a/app/src/app/components/validation-results/validation-results.component.ts
+++ b/app/src/app/components/validation-results/validation-results.component.ts
@@ -9,6 +9,7 @@ import { ValidationData } from 'src/app/classes/serializable';
 })
 export class ValidationResultsComponent implements OnInit {
     @Input() validation: ValidationData;
+    @Input() patchId: Boolean;
 
     constructor() {
         // intentionally left blank

--- a/app/src/app/views/stix/stix-page/stix-page.component.ts
+++ b/app/src/app/views/stix/stix-page/stix-page.component.ts
@@ -74,7 +74,7 @@ export class StixPageComponent implements OnInit, OnDestroy {
                 data: {
                     object: this.objects[0],
                     // patch LinkByIds on other objects if this object's ATT&CK ID has changed
-                    patchID: this.objects[0].supportsAttackID && this.objectID && this.objectID != this.objects[0].attackID ? this.objectID : undefined,
+                    patchId: this.objects[0].supportsAttackID && this.objectID && this.objectID != this.objects[0].attackID ? this.objectID : undefined,
                     versionAlreadyIncremented: versionChanged
                 },
 				autoFocus: false, // prevent auto focus on form field

--- a/app/src/app/views/stix/technique/technique-view/technique-view.component.html
+++ b/app/src/app/views/stix/technique/technique-view/technique-view.component.html
@@ -164,7 +164,7 @@
                 object: technique,
                 field: 'tactics',
                 editType: 'stixList',
-                disabled: technique.domains.length == 0
+                disabled: technique.domains.length == 0 || technique.is_subtechnique
             }"></app-list-property>
         </div>
         <ng-container *ngIf="showTacticField('privilege-escalation', 'permissions_required') || showTacticField('privilege-escalation', 'effective_permissions')

--- a/app/src/app/views/stix/technique/technique-view/technique-view.component.html
+++ b/app/src/app/views/stix/technique/technique-view/technique-view.component.html
@@ -20,7 +20,7 @@
         </div>
         <div class="col" [ngClass]="{'no-padding': editing}">
             <div class="labelled-box grow-to-row">
-                <!-- TYPE -->
+                <!-- SUB-TECHNIQUE? -->
                 <div class="content no-padding no-label">
                     <mat-checkbox color="primary" [(ngModel)]="technique.is_subtechnique" [disabled]="!editing">
                         sub-technique?

--- a/app/src/style/layouts/labelled-box.scss
+++ b/app/src/style/layouts/labelled-box.scss
@@ -6,11 +6,11 @@
     flex-direction: column;
     &.editing.disabled {
         .dark & {
-            border-color: border-color(dark) !important;
+            border-color: on-color-deemphasis(light) !important;
             border-top-color: transparent;
         }
         .light & {
-            border-color: border-color(light) !important;
+            border-color: on-color-deemphasis(dark) !important;
             border-top-color: transparent;
         }
     }

--- a/app/src/style/layouts/labelled-box.scss
+++ b/app/src/style/layouts/labelled-box.scss
@@ -4,7 +4,17 @@
     position: relative;
     display: flex;
     flex-direction: column;
-	&.editing {
+    &.editing.disabled {
+        .dark & {
+            border-color: border-color(dark) !important;
+            border-top-color: transparent;
+        }
+        .light & {
+            border-color: border-color(light) !important;
+            border-top-color: transparent;
+        }
+    }
+	&.editing:not(.disabled) {
 		> .content {
 			border: solid 1px;
 			&:hover {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,9 @@
 
 ### ATT&CK Workbench version 2.2.1
 
+#### Improvements
+- Implemented automatic synchronization of tactics between parent and sub-techniques to ensure consistency upon saving.
+
 #### Fixes
 - Fixed an issue where deprecated objects were not displayed in the "Objects citing this reference" section in the Reference Manager. The `includeDeprecatedObjects` property was added to the `stix-list` component, allowing these objects to be included in the list.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,10 +37,10 @@
 ### ATT&CK Workbench version 2.2.1
 
 #### Improvements
-- Implemented automatic synchronization of tactics between parent and sub-techniques to ensure consistency upon saving.
+- Implemented automatic synchronization of tactics between parent and sub-techniques to ensure consistency upon saving. See [frontend#583](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/pull/583).
 
 #### Fixes
-- Fixed an issue where deprecated objects were not displayed in the "Objects citing this reference" section in the Reference Manager. The `includeDeprecatedObjects` property was added to the `stix-list` component, allowing these objects to be included in the list.
+- Fixed an issue where deprecated objects were not displayed in the "Objects citing this reference" section in the Reference Manager. The `includeDeprecatedObjects` property was added to the `stix-list` component, allowing these objects to be included in the list. See [frontend#582](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/pull/582).
 
 ## 31 October 2024
 


### PR DESCRIPTION
Implements automatic synchronization of tactics between parent techniques and their associated sub-techniques:
- When a sub-technique is saved, its tactics will be synced with its parent.
- When a parent technique is saved with updated tactics, the tactics of linked sub-techniques will be updated.

This ensures data consistency and reduces manual effort, minimizing the risk of discrepancies between related techniques. Additionally, validation prompts have been added to the save dialog to inform users that this synchronization will occur.

Resolves #171 and #233 