### PR TITLE
Sub-technique can be Assigned as Its Own Parent

### DIFF
--- a/app/src/app/components/stix/list-property/list-edit/list-edit.component.ts
+++ b/app/src/app/components/stix/list-property/list-edit/list-edit.component.ts
@@ -124,7 +124,7 @@ export class ListEditComponent implements OnInit, AfterContentChecked {
             this.type = 'technique';
             const subscription = this.restAPIConnectorService.getAllTechniques().subscribe({
                 next: (r: Paginated<Technique>) => {
-                    this.allObjects = r.data.filter((t) => !t.is_subtechnique);
+                    this.allObjects = r.data.filter((t) => !t.is_subtechnique && t.stixID !== (this.config.object as Technique).stixID);
                     const selectableTechniqueIDs = r.data.map(t => t.stixID);
                     this.select = new SelectionModel<string>(false, selectableTechniqueIDs);
                     this.dataLoaded = true;


### PR DESCRIPTION
Fixed a bug that allowed users to assign a technique as a sub-technique of itself.

Closes https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/issues/586