### PR TITLE
Team Lead Updates

### DIFF
--- a/src/app/classes/authn/role.ts
+++ b/src/app/classes/authn/role.ts
@@ -2,6 +2,6 @@ export enum Role {
   NONE = 'none',
   VISITOR = 'visitor',
   EDITOR = 'editor',
-  TEAM_LEAD = 'team lead',
+  TEAM_LEAD = 'team_lead',
   ADMIN = 'admin',
 }

--- a/src/app/components/users-list/users-list.component.html
+++ b/src/app/components/users-list/users-list.component.html
@@ -109,11 +109,11 @@
               class="no-checkbox"
               *ngFor="let role of filterOptions[1].values"
               [value]="role"
-              >{{ role }}</mat-option
+              >{{ formatRole(role) }}</mat-option
             >
           </mat-select>
           <span *ngIf="!(isAdmin && user.id !== currentUser.id)">
-            {{ user.role }}
+            {{ formatRole(user.role) }}
           </span>
         </td>
       </ng-container>

--- a/src/app/components/users-list/users-list.component.ts
+++ b/src/app/components/users-list/users-list.component.ts
@@ -246,6 +246,15 @@ export class UsersListComponent implements OnInit {
     this.restAPIConnector.putTeam(this.team);
     this.applyControls();
   }
+
+  /**
+   * Formats role string by replacing underscores with spaces
+   * @param role The raw role string value (e.g., "team_lead")
+   * @returns A display-friendly version of the role
+   */
+  public formatRole(role: string): string {
+    return role.replace(/_/g, ' ');
+  }
 }
 
 export interface UsersListConfig {


### PR DESCRIPTION
This PR includes the following changes:
1. Updates TEAM_LEAD enum to team_lead to match the REST API
2. Helper function to format team_lead to 'team lead' in dropdown

To test:
1. Navigate to admin -> User Accounts
2. Click on the "role" dropdown. It should display "team lead"

Related to https://github.com/center-for-threat-informed-defense/attack-workbench-rest-api/pull/407