### PR TITLE
Team Lead Formatting in User Accounts Options Dropdown

### DIFF
--- a/src/app/components/users-list/users-list.component.html
+++ b/src/app/components/users-list/users-list.component.html
@@ -19,7 +19,7 @@
             *ngFor="let group of filterOptions"
             [label]="group.name">
             <mat-option *ngFor="let filter of group.values" [value]="filter">{{
-              'team_lead' ? formatRole(filter) : filter
+              formatRole(filter)
             }}</mat-option>
           </mat-optgroup>
         </mat-select>

--- a/src/app/components/users-list/users-list.component.html
+++ b/src/app/components/users-list/users-list.component.html
@@ -19,7 +19,7 @@
             *ngFor="let group of filterOptions"
             [label]="group.name">
             <mat-option *ngFor="let filter of group.values" [value]="filter">{{
-              filter
+              'team_lead' ? formatRole(filter) : filter
             }}</mat-option>
           </mat-optgroup>
         </mat-select>


### PR DESCRIPTION
Applies formatting to display 'team lead' instead of 'team_lead' in `/dashboard/user-accounts` options dropdown.