### PR TITLE
fix: use configurable reference field for mapping object references

### DIFF
--- a/src/app/components/stix/object-ref-property/object-ref-edit/object-ref-edit.component.ts
+++ b/src/app/components/stix/object-ref-property/object-ref-edit/object-ref-edit.component.ts
@@ -27,7 +27,8 @@ export class ObjectRefEditComponent implements OnInit, OnDestroy {
 
   public get objectRefs(): StixObject[] {
     if (!this.attackObjects || this.loading) return [];
-    const refIds = this.config.object[this.config.field].map(f => f.ref);
+    const refField = this.config.objectRefField.field;
+    const refIds = this.config.object[this.config.field].map(f => f[refField]);
     return refIds.map(id => this.attackObjects.find(o => o.stixID === id));
   }
 


### PR DESCRIPTION
Fixes an issue where the Log Source IDs were not being properly displayed when adding references to an Analytic object