### PR TITLE
Refactor ATT&CK ID generator

### DIFF
--- a/src/app/classes/stix/analytic.ts
+++ b/src/app/classes/stix/analytic.ts
@@ -16,7 +16,6 @@ export class Analytic extends StixObject {
   public relatedDetections: RelatedRef[] = [];
 
   public readonly supportsAttackID = true;
-  public readonly supportsNamespace = true;
   protected get attackIDValidator() {
     return {
       regex: 'AN\\d{4}',

--- a/src/app/classes/stix/asset.ts
+++ b/src/app/classes/stix/asset.ts
@@ -15,7 +15,6 @@ export class Asset extends StixObject {
   public domains: string[] = ['ics-attack'];
 
   public readonly supportsAttackID = true;
-  public readonly supportsNamespace = true;
   protected get attackIDValidator() {
     return {
       regex: 'A\\d{4}',
@@ -148,7 +147,7 @@ export class Asset extends StixObject {
    * Delete this STIX object from the database.
    * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
    */
-  public delete(restAPIService: RestApiConnectorService): Observable<{}> {
+  public delete(restAPIService: RestApiConnectorService): Observable<object> {
     const deleteObservable = restAPIService.deleteAsset(this.stixID);
     const subscription = deleteObservable.subscribe({
       complete: () => {

--- a/src/app/classes/stix/campaign.ts
+++ b/src/app/classes/stix/campaign.ts
@@ -14,7 +14,6 @@ export class Campaign extends StixObject {
   public contributors: string[] = [];
 
   public readonly supportsAttackID = true;
-  public readonly supportsNamespace = true;
   protected get attackIDValidator() {
     return {
       regex: 'C\\d{4}',
@@ -186,7 +185,7 @@ export class Campaign extends StixObject {
    * Delete this STIX object from the database.
    * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
    */
-  public delete(restAPIService: RestApiConnectorService): Observable<{}> {
+  public delete(restAPIService: RestApiConnectorService): Observable<object> {
     const deleteObservable = restAPIService.deleteCampaign(this.stixID);
     const subscription = deleteObservable.subscribe({
       complete: () => {

--- a/src/app/classes/stix/collection.ts
+++ b/src/app/classes/stix/collection.ts
@@ -205,7 +205,6 @@ export class Collection extends StixObject {
   ];
 
   public readonly supportsAttackID = false; // collections do not support ATT&CK IDs
-  public readonly supportsNamespace = false;
   protected readonly attackIDValidator = null; //collections do not have ATT&CK IDs
 
   constructor(sdo?: any) {

--- a/src/app/classes/stix/data-component.ts
+++ b/src/app/classes/stix/data-component.ts
@@ -18,7 +18,6 @@ export class DataComponent extends StixObject {
 
   // data components do not support ATT&CK IDs
   public readonly supportsAttackID = true;
-  public readonly supportsNamespace = true;
   protected get attackIDValidator() {
     return {
       regex: 'DC\\d{4}',

--- a/src/app/classes/stix/data-source.ts
+++ b/src/app/classes/stix/data-source.ts
@@ -15,7 +15,6 @@ export class DataSource extends StixObject {
   public data_components: DataComponent[] = [];
 
   public readonly supportsAttackID = true;
-  public readonly supportsNamespace = true;
   protected get attackIDValidator() {
     return {
       regex: 'DS\\d{4}',
@@ -159,7 +158,7 @@ export class DataSource extends StixObject {
    * Delete this STIX object from the database.
    * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
    */
-  public delete(restAPIService: RestApiConnectorService): Observable<{}> {
+  public delete(restAPIService: RestApiConnectorService): Observable<object> {
     const deleteObservable = restAPIService.deleteDataSource(this.stixID);
     const subscription = deleteObservable.subscribe({
       complete: () => {

--- a/src/app/classes/stix/detection-strategy.ts
+++ b/src/app/classes/stix/detection-strategy.ts
@@ -10,7 +10,6 @@ export class DetectionStrategy extends StixObject {
   public analytics: string[] = []; // list of x-mitre-analytic uuids
 
   public readonly supportsAttackID = true;
-  public readonly supportsNamespace = true;
   protected get attackIDValidator() {
     return {
       regex: 'DET\\d{4}',
@@ -48,7 +47,6 @@ export class DetectionStrategy extends StixObject {
    */
   public deserialize(raw: object) {
     if ('stix' in raw) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const sdo = raw.stix as any;
 
       if ('name' in sdo) {

--- a/src/app/classes/stix/group.ts
+++ b/src/app/classes/stix/group.ts
@@ -10,7 +10,6 @@ export class Group extends StixObject {
   public contributors: string[] = [];
 
   public readonly supportsAttackID = true;
-  public readonly supportsNamespace = true;
   protected get attackIDValidator() {
     return {
       regex: 'G\\d{4}',
@@ -125,7 +124,7 @@ export class Group extends StixObject {
    * Delete this STIX object from the database.
    * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
    */
-  public delete(restAPIService: RestApiConnectorService): Observable<{}> {
+  public delete(restAPIService: RestApiConnectorService): Observable<object> {
     const deleteObservable = restAPIService.deleteGroup(this.stixID);
     const subscription = deleteObservable.subscribe({
       complete: () => {

--- a/src/app/classes/stix/identity.ts
+++ b/src/app/classes/stix/identity.ts
@@ -11,7 +11,6 @@ export class Identity extends StixObject {
   public contact?: string; // contact information for this identity
 
   public readonly supportsAttackID = false; // Identity does not support ATT&CK IDs
-  public readonly supportsNamespace = false;
   protected get attackIDValidator() {
     return null;
   } // identities do not have an ATT&CK ID
@@ -123,7 +122,7 @@ export class Identity extends StixObject {
     return postObservable;
   }
 
-  public delete(_restAPIService: RestApiConnectorService): Observable<{}> {
+  public delete(_restAPIService: RestApiConnectorService): Observable<object> {
     // deletion is not supported on Identity objects
     return of({});
   }

--- a/src/app/classes/stix/marking-definition.ts
+++ b/src/app/classes/stix/marking-definition.ts
@@ -11,7 +11,6 @@ export class MarkingDefinition extends StixObject {
   public definition_string = '';
 
   public readonly supportsAttackID = false; // marking-defs do not support ATT&CK IDs
-  public readonly supportsNamespace = false;
   protected get attackIDValidator() {
     return null;
   } //marking-defs do not have ATT&CK IDs
@@ -163,12 +162,12 @@ export class MarkingDefinition extends StixObject {
     return postObservable;
   }
 
-  public delete(_restAPIService: RestApiConnectorService): Observable<{}> {
+  public delete(_restAPIService: RestApiConnectorService): Observable<object> {
     // deletion is not supported on Marking Definitions
     return of({});
   }
 
-  public update(_restAPIService: RestApiConnectorService): Observable<{}> {
+  public update(_restAPIService: RestApiConnectorService): Observable<object> {
     // update is not supported on Marking Definitions
     return of({});
   }

--- a/src/app/classes/stix/matrix.ts
+++ b/src/app/classes/stix/matrix.ts
@@ -12,7 +12,6 @@ export class Matrix extends StixObject {
   public tactic_objects: Tactic[] = [];
 
   public readonly supportsAttackID = true;
-  public readonly supportsNamespace = true;
   protected get attackIDValidator() {
     return {
       regex: '.*',
@@ -110,7 +109,7 @@ export class Matrix extends StixObject {
     return postObservable;
   }
 
-  public delete(_restAPIService: RestApiConnectorService): Observable<{}> {
+  public delete(_restAPIService: RestApiConnectorService): Observable<object> {
     // deletion is not supported on Matrix objects
     return of({});
   }

--- a/src/app/classes/stix/mitigation.ts
+++ b/src/app/classes/stix/mitigation.ts
@@ -10,7 +10,6 @@ export class Mitigation extends StixObject {
   public securityControls: string[] = [];
 
   public readonly supportsAttackID = true;
-  public readonly supportsNamespace = true;
   protected get attackIDValidator() {
     return {
       regex: 'M\\d{4}',

--- a/src/app/classes/stix/note.ts
+++ b/src/app/classes/stix/note.ts
@@ -11,7 +11,6 @@ export class Note extends StixObject {
   public editing = false;
 
   public readonly supportsAttackID = false; // notes do not support ATT&CK IDs
-  public readonly supportsNamespace = false;
   protected get attackIDValidator() {
     return null;
   } // notes have no ATT&CK ID
@@ -115,7 +114,7 @@ export class Note extends StixObject {
    * Delete this STIX object from the database.
    * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
    */
-  public delete(restAPIService: RestApiConnectorService): Observable<{}> {
+  public delete(restAPIService: RestApiConnectorService): Observable<object> {
     const deleteObservable = restAPIService.deleteNote(this.stixID);
     const subscription = deleteObservable.subscribe({
       complete: () => {

--- a/src/app/classes/stix/relationship.ts
+++ b/src/app/classes/stix/relationship.ts
@@ -40,7 +40,6 @@ export class Relationship extends StixObject {
   public relationship_type = '';
 
   public readonly supportsAttackID = false; // relationships do not have ATT&CK IDs
-  public readonly supportsNamespace = false; // relationships do not support namespacing
   protected get attackIDValidator() {
     return null;
   } // relationships have no ATT&CK ID

--- a/src/app/classes/stix/software.ts
+++ b/src/app/classes/stix/software.ts
@@ -15,7 +15,6 @@ export class Software extends StixObject {
   public domains: string[] = [];
 
   public readonly supportsAttackID = true;
-  public readonly supportsNamespace = true;
   protected get attackIDValidator() {
     return {
       regex: 'S\\d{4}',

--- a/src/app/classes/stix/tactic.ts
+++ b/src/app/classes/stix/tactic.ts
@@ -14,7 +14,6 @@ export class Tactic extends StixObject {
   public technique_objects: Technique[] = [];
 
   public readonly supportsAttackID = true;
-  public readonly supportsNamespace = true;
   protected get attackIDValidator() {
     return {
       regex: 'TA\\d{4}',
@@ -123,7 +122,7 @@ export class Tactic extends StixObject {
     return postObservable;
   }
 
-  public delete(_restAPIService: RestApiConnectorService): Observable<{}> {
+  public delete(_restAPIService: RestApiConnectorService): Observable<object> {
     // deletion is not supported on Tactic objects
     return of({});
   }

--- a/src/app/classes/stix/technique.ts
+++ b/src/app/classes/stix/technique.ts
@@ -25,7 +25,6 @@ export class Technique extends StixObject {
   public show_subtechniques = false; // used by matrix view to handle displaying subtechniques
 
   public readonly supportsAttackID = true;
-  public readonly supportsNamespace = true;
   protected get attackIDValidator() {
     return {
       regex: this.is_subtechnique ? 'T\\d{4}\\.\\d{3}' : 'T\\d{4}',
@@ -746,7 +745,7 @@ export class Technique extends StixObject {
    * Delete this STIX object from the database.
    * @param restAPIService [RestApiConnectorService] the service to perform the DELETE through
    */
-  public delete(restAPIService: RestApiConnectorService): Observable<{}> {
+  public delete(restAPIService: RestApiConnectorService): Observable<object> {
     const deleteObservable = restAPIService.deleteTechnique(this.stixID);
     const subscription = deleteObservable.subscribe({
       complete: () => {

--- a/src/app/components/stix/attackid-property/attackid-edit/attackid-edit.component.html
+++ b/src/app/components/stix/attackid-property/attackid-edit/attackid-edit.component.html
@@ -1,18 +1,12 @@
 <div class="attackid-edit">
-  <mat-form-field
-    appearance="outline"
-    [matTooltip]="
-      showHint
-        ? 'ID prefix appended is based on your organization\'s namespace settings'
-        : null
-    ">
+  <mat-form-field appearance="outline">
     <mat-label>ID</mat-label>
     <input
       matInput
       [required]="config.required ? config.required : false"
       [(ngModel)]="config.object['attackID']"
       (ngModelChange)="attackIdChanged()"
-      (blur)="prependPrefix()" />
+      (blur)="formatAttackId()" />
     <button
       *ngIf="
         config.object['supportsAttackID'] &&

--- a/src/app/views/stix/analytic-view/analytic-view.component.ts
+++ b/src/app/views/stix/analytic-view/analytic-view.component.ts
@@ -33,27 +33,12 @@ export class AnalyticViewComponent extends StixViewPage implements OnInit {
   }
 
   private generateAttackId(): void {
-    this.apiService.getOrganizationNamespace().subscribe({
-      next: namespaceSettings => {
-        const prefix = namespaceSettings.prefix
-          ? namespaceSettings.prefix + '-'
-          : '';
-        const range_start = namespaceSettings.range_start;
-
-        // generate the ATT&CK ID
-        const sub = this.analytic
-          .getNamespaceID(this.apiService, {
-            prefix,
-            range_start,
-          })
-          .subscribe({
-            next: val => {
-              this.analytic.attackID = val;
-              this.setNameFromAttackId();
-            },
-            complete: () => sub.unsubscribe(),
-          });
+    const sub = this.analytic.generateAttackId(this.apiService).subscribe({
+      next: val => {
+        this.analytic.attackID = val;
+        this.setNameFromAttackId();
       },
+      complete: () => sub.unsubscribe(),
     });
   }
 


### PR DESCRIPTION
Summary of Changes:

- `generateAttackID()` fetches the organization namespace internally, removing the need to pass it in from callers
- Centralizes prefix handling: IDs are formatted consistently and callers no longer need to handle formatting separately
- Removes redundant `supportsNamespace` boolean from all SDOs
- Simplifies and improves calculation logic for the next available ATT&CK ID
- Improve general readability and maintainability