### PR TITLE
feat(data-components): show domain filter

### DIFF
--- a/src/app/components/stix/stix-list/stix-list.component.ts
+++ b/src/app/components/stix/stix-list/stix-list.component.ts
@@ -534,6 +534,7 @@ export class StixListComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     const filterByDomain: boolean = this.config.type
       ? [
+          'data-component',
           'data-source',
           'mitigation',
           'software',


### PR DESCRIPTION
## Why
Addresses #767.
Related REST API issue: [rest-api#453](https://github.com/center-for-threat-informed-defense/attack-workbench-rest-api/issues/453).

Data Components should expose the existing Domain filter in the shared STIX list UI once the REST API supports filtering them by domain.

## What Changed
- Add `data-component` to the shared STIX list domain-filter allowlist.
- Reuse the existing REST connector behavior that sends selected domains as repeated `domain` query params.

## How To Verify
- `npx prettier src/app/components/stix/stix-list/stix-list.component.ts --check`
- Rebuilt the local Docker stack and confirmed the frontend production build completed.
- Exercised filter on built/served view
