### PR TITLE
feat(docker): add frontend live reload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,20 @@
+FROM node:22-alpine AS dev
+
+WORKDIR /workspace
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN mkdir -p /workspace-seed && cp -R src /workspace-seed/src
+
+# Polling makes file watching reliable with Docker bind mounts.
+ENV CHOKIDAR_USEPOLLING=true
+
+EXPOSE 80 4200
+
+CMD ["sh", "-c", "if [ ! -f src/main.ts ]; then cp -R /workspace-seed/src/. src/; fi; exec npm start -- --host 0.0.0.0 --port 80 --poll 1000"]
+
 FROM --platform=${BUILDPLATFORM} node:22-alpine AS build
 
 WORKDIR /workspace

--- a/src/app/views/landing-page/landing-page.component.html
+++ b/src/app/views/landing-page/landing-page.component.html
@@ -9,7 +9,7 @@
       <!-- About -->
     </div>
     <div class="col border-left">
-      <h2 class="explore-label">Explore Live</h2>
+      <h2 class="explore-label">Explore</h2>
     </div>
   </div>
   <div class="row">

--- a/src/app/views/landing-page/landing-page.component.html
+++ b/src/app/views/landing-page/landing-page.component.html
@@ -9,7 +9,7 @@
       <!-- About -->
     </div>
     <div class="col border-left">
-      <h2 class="explore-label">Explore</h2>
+      <h2 class="explore-label">Explore Live</h2>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Why

This supports the cross-service hot-reload development workflow by letting frontend changes be verified quickly inside the local Compose stack instead of rebuilding the frontend image for each edit.

## What Changed

- Adds a frontend `dev` Docker target.
- Installs dependencies with `npm ci`, seeds `src`, and runs Angular's dev server on port 80.
- Enables polling with `CHOKIDAR_USEPOLLING=true` and `--poll 1000` so file changes synced by Compose Watch are detected reliably in Docker.

## How To Verify

Start a developer-mode Compose stack with watch enabled from the deployment repo:

    ./docker/setup-workbench.sh --accept-defaults --dev-mode --taxii-server --instance-name live-reload-smoke
    cd instances/live-reload-smoke
    docker compose up --watch --build

Verify frontend reload:

    $EDITOR ../../../attack-workbench-frontend/src/app/views/landing-page/landing-page.component.html +12

Temporarily change `Explore` to `Explore Live`. Confirm the frontend updates in the browser after reload/HMR, then revert the temporary text change.

## Related PRs

- Deployment: https://github.com/mitre-attack/attack-workbench-deployment/pull/6

## Landing

Merge before the deployment live-reload PR.
