### PR TITLE
Add Identity Controls + ADM Validation Bypasses Dashboard

### DIFF
--- a/src/app/app-routing-stix.module.ts
+++ b/src/app/app-routing-stix.module.ts
@@ -78,6 +78,12 @@ const stixRouteData = [
     headerSection: 'defenses',
     deprecated: true,
   },
+  // more
+  {
+    attackType: 'identity',
+    editable: true,
+    headerSection: 'more',
+  },
 ];
 
 const stixRoutes: Routes = [];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -45,6 +45,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatSortModule } from '@angular/material/sort';
 import { MatStepperModule } from '@angular/material/stepper';
@@ -185,6 +186,7 @@ import { CampaignViewComponent } from './views/stix/campaign-view/campaign-view.
 import { DataComponentViewComponent } from './views/stix/data-component-view/data-component-view.component';
 import { DataSourceViewComponent } from './views/stix/data-source-view/data-source-view.component';
 import { GroupViewComponent } from './views/stix/group-view/group-view.component';
+import { IdentityViewComponent } from './views/stix/identity-view/identity-view.component';
 import { MarkingDefinitionViewComponent } from './views/stix/marking-definition-view/marking-definition-view.component';
 import { MatrixFlatComponent } from './views/stix/matrix/matrix-flat/matrix-flat.component';
 import { MatrixSideComponent } from './views/stix/matrix/matrix-side/matrix-side.component';
@@ -328,6 +330,7 @@ export function initConfig(appConfigService: AppConfigService) {
     IdentityPropertyComponent,
     DataSourceViewComponent,
     DataComponentViewComponent,
+    IdentityViewComponent,
     MarkingDefinitionViewComponent,
     CampaignViewComponent,
     CitationPropertyComponent,
@@ -394,6 +397,7 @@ export function initConfig(appConfigService: AppConfigService) {
     MatSelectModule,
     MatExpansionModule,
     MatCheckboxModule,
+    MatSlideToggleModule,
     MatRadioModule,
     MatProgressSpinnerModule,
     MatMenuModule,
@@ -441,6 +445,7 @@ export function initConfig(appConfigService: AppConfigService) {
     MatSelectModule,
     MatExpansionModule,
     MatCheckboxModule,
+    MatSlideToggleModule,
     MatRadioModule,
     MatProgressSpinnerModule,
     MatMenuModule,

--- a/src/app/classes/stix/identity.ts
+++ b/src/app/classes/stix/identity.ts
@@ -1,4 +1,4 @@
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { RestApiConnectorService } from 'src/app/services/connectors/rest-api/rest-api-connector.service';
 import { logger } from '../../utils/logger';
 import { ValidationData } from '../serializable';
@@ -8,7 +8,8 @@ import { WorkflowState } from 'src/app/utils/types';
 export class Identity extends StixObject {
   public name: string; // identity name
   public identity_class: string; // type of entity this identity describes
-  public roles?: string[]; // list of roles this identity performs
+  public roles: string[] = []; // list of roles this identity performs
+  public sectors: string[] = []; // list of sectors this identity belongs to
   public contact?: string; // contact information for this identity
 
   public readonly supportsAttackID = false; // Identity does not support ATT&CK IDs
@@ -24,6 +25,7 @@ export class Identity extends StixObject {
     if (sdo) {
       this.deserialize(sdo);
     }
+    this.workflow = undefined;
   }
 
   /**
@@ -37,6 +39,7 @@ export class Identity extends StixObject {
     rep.stix.name = this.name;
     rep.stix.identity_class = this.identity_class;
     if (this.roles) rep.stix.roles = this.roles;
+    if (this.sectors?.length) rep.stix.sectors = this.sectors;
     if (this.contact) rep.stix.contact_information = this.contact;
 
     // Strip properties that are empty strs + lists
@@ -82,6 +85,15 @@ export class Identity extends StixObject {
       if ('roles' in sdo) {
         if (this.isStringArray(sdo.roles)) this.roles = sdo.roles;
         else logger.error('TypeError: roles field is not a string array.');
+      } else {
+        this.roles = [];
+      }
+
+      if ('sectors' in sdo) {
+        if (this.isStringArray(sdo.sectors)) this.sectors = sdo.sectors;
+        else logger.error('TypeError: sectors field is not a string array.');
+      } else {
+        this.sectors = [];
       }
 
       if ('contact_information' in sdo) {
@@ -106,9 +118,9 @@ export class Identity extends StixObject {
    */
   public validate(
     restAPIService: RestApiConnectorService,
-    tempWorkflowState?: WorkflowState
+    _tempWorkflowState?: WorkflowState
   ): Observable<ValidationData> {
-    return this.base_validate(restAPIService, tempWorkflowState);
+    return this.base_validate(restAPIService);
   }
 
   /**
@@ -130,9 +142,14 @@ export class Identity extends StixObject {
     return postObservable;
   }
 
-  public delete(_restAPIService: RestApiConnectorService): Observable<object> {
-    // deletion is not supported on Identity objects
-    return of({});
+  public delete(restAPIService: RestApiConnectorService): Observable<object> {
+    const deleteObservable = restAPIService.deleteIdentity(this.stixID);
+    const subscription = deleteObservable.subscribe({
+      complete: () => {
+        subscription.unsubscribe();
+      },
+    });
+    return deleteObservable;
   }
 
   /**

--- a/src/app/classes/stix/stix-object.ts
+++ b/src/app/classes/stix/stix-object.ts
@@ -17,6 +17,7 @@ import { v4 as uuid } from 'uuid';
 import { logger } from '../../utils/logger';
 import { ExternalReferences } from '../external-references';
 import { Serializable, ValidationData } from '../serializable';
+import { UserAccount } from '../authn/user-account';
 import { VersionNumber } from '../version-number';
 
 export type workflowStates =
@@ -35,6 +36,7 @@ export abstract class StixObject extends Serializable {
   public created_by?: any;
   public modified_by_ref: string; //embedded relationship
   public modified_by?: any;
+  public created_by_user_account?: UserAccount;
   public firstInitialized: boolean; // boolean to track if it is a newly created object
 
   public object_marking_refs: string[] = []; //list of embedded relationships to marking_defs
@@ -356,6 +358,11 @@ export abstract class StixObject extends Serializable {
         logger.error(
           "ObjectError: 'stix' field does not exist in modified_by_identity object"
         );
+    }
+    if ('created_by_user_account' in raw && raw.created_by_user_account) {
+      this.created_by_user_account = new UserAccount(
+        raw.created_by_user_account
+      );
     }
 
     if ('workspace' in raw) {

--- a/src/app/components/confirmation-dialog/confirmation-dialog.component.html
+++ b/src/app/components/confirmation-dialog/confirmation-dialog.component.html
@@ -6,6 +6,13 @@
       ><span *ngIf="config.no_suffix">, {{ config.no_suffix }}</span>
     </button>
     <button
+      *ngIf="config.alternate_label"
+      mat-button
+      [mat-dialog-close]="config.alternate_value || 'alternate'"
+      class="text-label">
+      <span>{{ config.alternate_label }}</span>
+    </button>
+    <button
       mat-stroked-button
       color="warn"
       [mat-dialog-close]="true"

--- a/src/app/components/confirmation-dialog/confirmation-dialog.component.ts
+++ b/src/app/components/confirmation-dialog/confirmation-dialog.component.ts
@@ -22,4 +22,6 @@ export interface ConfirmationDialogConfig {
   message: string; //prompt text
   yes_suffix?: string; //optional suffix to add to the yes button
   no_suffix?: string; //optional suffix to add to the no button
+  alternate_label?: string; //optional label for a third button
+  alternate_value?: string; //optional value returned by the third button
 }

--- a/src/app/components/save-dialog/save-dialog.component.html
+++ b/src/app/components/save-dialog/save-dialog.component.html
@@ -15,7 +15,10 @@
     </div>
     <div class="column narrow version-buttons">
       <mat-action-list>
-        <mat-form-field class="workflow-status" appearance="outline">
+        <mat-form-field
+          *ngIf="workflowEnabled"
+          class="workflow-status"
+          appearance="outline">
           <mat-label>mark as...</mat-label>
           <mat-select
             [(ngModel)]="newState"

--- a/src/app/components/save-dialog/save-dialog.component.ts
+++ b/src/app/components/save-dialog/save-dialog.component.ts
@@ -31,6 +31,10 @@ export class SaveDialogComponent implements OnInit {
     return this.validation && this.validation.errors.length == 0;
   }
 
+  public get workflowEnabled(): boolean {
+    return this.config.showWorkflow !== false;
+  }
+
   constructor(
     public dialogRef: MatDialogRef<SaveDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public config: SaveDialogConfig,
@@ -64,7 +68,9 @@ export class SaveDialogComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.newState = this.config.initialWorkflowState || 'work-in-progress';
+    this.newState = this.workflowEnabled
+      ? this.config.initialWorkflowState || 'work-in-progress'
+      : undefined;
     if (this.config.object.attackType === 'relationship') {
       this.newState = undefined;
     }
@@ -91,7 +97,10 @@ export class SaveDialogComponent implements OnInit {
     }
     // Run validation for the initial state
     const subscription = this.config.object
-      .validate(this.restApiService, this.newState)
+      .validate(
+        this.restApiService,
+        this.workflowEnabled ? this.newState : undefined
+      )
       .subscribe({
         next: result => {
           this.validation = result;
@@ -104,6 +113,8 @@ export class SaveDialogComponent implements OnInit {
   }
 
   onStatusChanged(event) {
+    if (!this.workflowEnabled) return;
+
     const subscription = this.config.object
       .validate(this.restApiService, event.value)
       .subscribe({
@@ -225,9 +236,7 @@ export class SaveDialogComponent implements OnInit {
    * Save the object with the current version and check for patches
    */
   public saveCurrentVersion() {
-    this.config.object.workflow = this.newState
-      ? { state: this.newState }
-      : undefined;
+    this.applyWorkflowState();
     if (this.config.patchId || this.config.patchAnalytics) this.parse_patches();
     else this.save();
   }
@@ -237,9 +246,7 @@ export class SaveDialogComponent implements OnInit {
    */
   public saveNextMinorVersion() {
     this.config.object.version = new VersionNumber(this.nextMinorVersion);
-    this.config.object.workflow = this.newState
-      ? { state: this.newState }
-      : undefined;
+    this.applyWorkflowState();
     if (this.config.patchId || this.config.patchAnalytics) this.parse_patches();
     else this.save();
   }
@@ -249,11 +256,16 @@ export class SaveDialogComponent implements OnInit {
    */
   public saveNextMajorVersion() {
     this.config.object.version = new VersionNumber(this.nextMajorVersion);
-    this.config.object.workflow = this.newState
-      ? { state: this.newState }
-      : undefined;
+    this.applyWorkflowState();
     if (this.config.patchId || this.config.patchAnalytics) this.parse_patches();
     else this.save();
+  }
+
+  private applyWorkflowState(): void {
+    this.config.object.workflow =
+      this.workflowEnabled && this.newState
+        ? { state: this.newState }
+        : undefined;
   }
 
   private saveObject() {
@@ -267,7 +279,7 @@ export class SaveDialogComponent implements OnInit {
     if (!this.saveEnabled) {
       return;
     }
-    this.config.object.workflow = { state: this.newState };
+    this.applyWorkflowState();
     const sub = this.saveObject().subscribe({
       next: () => {
         this.dialogRef.close(true);
@@ -283,4 +295,5 @@ export interface SaveDialogConfig {
   patchAnalytics?: Set<string>; // previous list of analytics related to a detection strategy
   versionAlreadyIncremented: boolean;
   initialWorkflowState?: WorkflowState;
+  showWorkflow?: boolean;
 }

--- a/src/app/components/stix/identity-property/identity-property.component.ts
+++ b/src/app/components/stix/identity-property/identity-property.component.ts
@@ -2,8 +2,6 @@ import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { Identity } from 'src/app/classes/stix/identity';
 import { StixObject } from 'src/app/classes/stix/stix-object';
 import { AuthenticationService } from '../../../services/connectors/authentication/authentication.service';
-import { RestApiConnectorService } from '../../../services/connectors/rest-api/rest-api-connector.service';
-import { Subscription } from 'rxjs';
 import { UserAccount } from 'src/app/classes/authn/user-account';
 
 @Component({
@@ -17,12 +15,8 @@ export class IdentityPropertyComponent implements OnInit {
   @Input() public config: IdentityPropertyConfig;
 
   public identity: Identity;
-  private userSubscription$: Subscription;
 
-  constructor(
-    private authenticationService: AuthenticationService,
-    private restAPIConnector: RestApiConnectorService
-  ) {}
+  constructor(private authenticationService: AuthenticationService) {}
 
   ngOnInit(): void {
     const object = Array.isArray(this.config.object)
@@ -36,19 +30,11 @@ export class IdentityPropertyComponent implements OnInit {
     if (
       this.authenticationService.isLoggedIn &&
       this.config.field.includes('modified') &&
-      object?.['workflow']?.['created_by_user_account']
+      object?.['created_by_user_account']
     ) {
-      const userID = object.workflow.created_by_user_account;
-      this.userSubscription$ = this.restAPIConnector
-        .getUserAccount(userID)
-        .subscribe({
-          next: account => {
-            const user = new UserAccount(account);
-            if (!this.identity) this.identity = new Identity();
-            this.identity.name = user.displayName;
-          },
-          complete: () => this.userSubscription$.unsubscribe(),
-        });
+      const user = new UserAccount(object.created_by_user_account);
+      if (!this.identity) this.identity = new Identity();
+      this.identity.name = user.displayName;
     }
   }
 }

--- a/src/app/components/stix/list-property/list-edit/list-edit.component.ts
+++ b/src/app/components/stix/list-property/list-edit/list-edit.component.ts
@@ -63,7 +63,7 @@ export class ListEditComponent implements OnInit, AfterContentChecked {
     permissions_required: 'x_mitre_permissions_required',
     collection_layers: 'x_mitre_collection_layers',
     data_sources: 'x_mitre_data_sources',
-    sectors: 'x_mitre_sectors',
+    sectors: 'sectors',
   };
   public domains = ['enterprise-attack', 'mobile-attack', 'ics-attack'];
 
@@ -299,7 +299,7 @@ export class ListEditComponent implements OnInit, AfterContentChecked {
     // filter values
     const values = new Set<string>();
     const property = this.allAllowedValues.properties.find(p => {
-      return p.propertyName == this.fieldToStix[this.config.field];
+      return p.propertyName == this.allowedValuesPropertyName();
     });
     if (!property) {
       // property not found
@@ -335,6 +335,14 @@ export class ListEditComponent implements OnInit, AfterContentChecked {
       this.selectControl.enable(); // re-enable field
     }
     return values;
+  }
+
+  private allowedValuesPropertyName(): string {
+    const object = this.config.object as StixObject;
+    if (object.attackType === 'asset' && this.config.field === 'sectors') {
+      return 'x_mitre_sectors';
+    }
+    return this.fieldToStix[this.config.field];
   }
 
   /** Add value to object property list */

--- a/src/app/components/stix/name-property/name-property.component.ts
+++ b/src/app/components/stix/name-property/name-property.component.ts
@@ -40,7 +40,7 @@ export class NamePropertyComponent implements OnInit {
     return (
       this.config.mode === 'view' &&
       this.object instanceof StixObject &&
-      this.object.attackType !== 'collection'
+      !['collection', 'identity'].includes(this.object.attackType)
     );
   }
 
@@ -100,6 +100,8 @@ export class NamePropertyComponent implements OnInit {
   }
 
   public workflowChange(event): void {
+    if (!this.showWorkflowControl) return;
+
     const previousWorkflowState =
       this.object?.workflow?.state || 'work-in-progress';
     if (event.isUserInput) {
@@ -110,6 +112,7 @@ export class NamePropertyComponent implements OnInit {
           object: this.object,
           versionAlreadyIncremented: false,
           initialWorkflowState: event.source.value,
+          showWorkflow: true,
         },
         autoFocus: false,
       });

--- a/src/app/components/stix/stix-list/stix-list.component.ts
+++ b/src/app/components/stix/stix-list/stix-list.component.ts
@@ -320,6 +320,12 @@ export class StixListComponent implements OnInit, AfterViewInit, OnDestroy {
           this.addDomainColumn();
           this.addColumn('modified', 'modified', 'timestamp');
           break;
+        case 'identity':
+          this.addWorkflowAndStateColumns();
+          this.addNameColumn(sticky_allowed);
+          this.addColumn('identity class', 'identity_class', 'plain');
+          this.addColumn('modified', 'modified', 'timestamp');
+          break;
         case 'data-source':
         case 'technique':
           this.addWorkflowAndStateColumns();
@@ -974,6 +980,8 @@ export class StixListComponent implements OnInit, AfterViewInit, OnDestroy {
     else if (this.config.type == 'marking-definition')
       this.data$ =
         this.restAPIConnectorService.getAllMarkingDefinitions(options);
+    else if (this.config.type == 'identity')
+      this.data$ = this.restAPIConnectorService.getAllIdentities(options);
     else if (this.config.type == 'note')
       this.data$ = this.restAPIConnectorService.getAllNotes(options);
     const subscription = this.data$.subscribe({

--- a/src/app/components/stix/string-property/string-property.component.ts
+++ b/src/app/components/stix/string-property/string-property.component.ts
@@ -27,6 +27,10 @@ export class StringPropertyComponent implements OnInit, OnChanges {
   public allowedValues: any;
   public channels: Set<string>;
   public loading = false;
+  private fieldToAllowedValuesProperty = {
+    identity_class: 'identity_class',
+    platform: 'x_mitre_platforms',
+  };
 
   // prevent async issues
   private subscription: Subscription = new Subscription();
@@ -47,7 +51,7 @@ export class StringPropertyComponent implements OnInit, OnChanges {
         disabled: this.config.disabled ?? false,
       });
 
-      if (this.config.field === 'platform') {
+      if (this.fieldToAllowedValuesProperty[this.config.field]) {
         this.loading = true;
         const data$ = this.apiService.getAllAllowedValues();
         this.subscription = data$.subscribe({
@@ -79,16 +83,21 @@ export class StringPropertyComponent implements OnInit, OnChanges {
   public getOptions(): Set<string> {
     const options = new Set<string>();
     if (this.loading) return options;
-    if (this.config.field === 'platform') {
+    const allowedValuesProperty =
+      this.fieldToAllowedValuesProperty[this.config.field];
+    if (allowedValuesProperty) {
       const obj = this.config.object as any;
-      const properties = this.allowedValues.properties.find(p => {
-        return p.propertyName == 'x_mitre_platforms';
+      const properties = this.allowedValues?.properties?.find(p => {
+        return p.propertyName == allowedValuesProperty;
       });
       properties?.domains?.forEach(d => {
-        if (obj?.domains?.includes(d.domainName)) {
+        if (!obj?.domains || obj.domains.includes(d.domainName)) {
           d.allowedValues.forEach(options.add, options);
         }
       });
+      if (this.config.object[this.config.field]) {
+        options.add(this.config.object[this.config.field]);
+      }
     }
     return options;
   }

--- a/src/app/components/stix/timestamp-property/timestamp-property.component.ts
+++ b/src/app/components/stix/timestamp-property/timestamp-property.component.ts
@@ -23,9 +23,8 @@ export class TimestampPropertyComponent implements OnInit {
     return (
       this.config.field.includes('modified') &&
       this.config.object &&
-      'workflow' in this.config.object &&
-      this.config.object.workflow &&
-      'created_by_user_account' in this.config.object.workflow
+      'created_by_user_account' in this.config.object &&
+      !!this.config.object.created_by_user_account
     );
   }
 }

--- a/src/app/components/stix/timestamp-property/timestamp-view/timestamp-view.component.ts
+++ b/src/app/components/stix/timestamp-property/timestamp-view/timestamp-view.component.ts
@@ -1,8 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { TimestampPropertyConfig } from '../timestamp-property.component';
 import moment from 'moment';
-import { RestApiConnectorService } from 'src/app/services/connectors/rest-api/rest-api-connector.service';
-import { Subscription } from 'rxjs';
 import { UserAccount } from 'src/app/classes/authn/user-account';
 
 @Component({
@@ -15,10 +13,9 @@ export class TimestampViewComponent implements OnInit {
   @Input() public config: TimestampPropertyConfig;
 
   private _humanized: string = null;
-  private userSubscription$: Subscription;
   displayName = '';
 
-  constructor(private restAPIConnector: RestApiConnectorService) {
+  constructor() {
     // intentionally left blank
   }
 
@@ -27,20 +24,11 @@ export class TimestampViewComponent implements OnInit {
       const object = Array.isArray(this.config.object)
         ? this.config.object[0]
         : this.config.object;
-      const createdByAccountId = object.workflow.created_by_user_account;
-      if (!createdByAccountId) {
-        // createdByAccountId does not exist
+      if (!object?.created_by_user_account) {
         return;
       }
-      this.userSubscription$ = this.restAPIConnector
-        .getUserAccount(createdByAccountId)
-        .subscribe({
-          next: response => {
-            const user = new UserAccount(response);
-            this.displayName = user.displayName;
-          },
-          complete: () => this.userSubscription$.unsubscribe(),
-        });
+      const user = new UserAccount(object.created_by_user_account);
+      this.displayName = user.displayName;
     }
   }
 

--- a/src/app/services/connectors/api-connector.ts
+++ b/src/app/services/connectors/api-connector.ts
@@ -14,7 +14,9 @@ export abstract class ApiConnector {
    */
   private errorSnack(error: any) {
     // show error field if it's a string (for some error's it's a string, for some it's an Object)
-    if ('error' in error && typeof error.error == 'string')
+    if ('error' in error && typeof error.error?.message == 'string')
+      this.snack(error.error.message, 'warn');
+    else if ('error' in error && typeof error.error == 'string')
       this.snack(error.error, 'warn');
     // otherwise, try showing the message
     else if ('message' in error) this.snack(error.message, 'warn');
@@ -63,7 +65,7 @@ export abstract class ApiConnector {
    */
   private snack(message: string, snackType?: 'warn' | 'success'): void {
     this.theSnackbar.open(message, 'dismiss', {
-      duration: 2000,
+      duration: snackType === 'warn' ? 6000 : 2000,
       panelClass: snackType,
     });
   }

--- a/src/app/services/connectors/rest-api/rest-api-connector.service.ts
+++ b/src/app/services/connectors/rest-api/rest-api-connector.service.ts
@@ -69,6 +69,10 @@ export interface Namespace {
   range_start: string;
 }
 
+export interface MitreIdentityWrites {
+  enabled: boolean;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -1175,6 +1179,20 @@ export class RestApiConnectorService extends ApiConnector {
               warnings: error.error.warnings || [],
             });
           }
+          if (error.status === 400) {
+            return of({
+              errors: [
+                {
+                  path: ['request'],
+                  message:
+                    typeof error.error === 'string'
+                      ? error.error
+                      : error.error?.message || 'Validation failed.',
+                },
+              ],
+              warnings: [],
+            });
+          }
           // Non-validation errors: re-raise
           return throwError(error);
         }),
@@ -1606,6 +1624,14 @@ export class RestApiConnectorService extends ApiConnector {
    */
   public get deleteMatrix() {
     return this.deleteStixObjectFactory('matrix');
+  }
+  /**
+   * DELETE an identity
+   * @param {string} id the STIX ID of the object to delete
+   * @returns {Observable<{}>} observable of the response body
+   */
+  public get deleteIdentity() {
+    return this.deleteStixObjectFactory('identity');
   }
   /**
    * REVOKE a technique
@@ -2543,6 +2569,21 @@ export class RestApiConnectorService extends ApiConnector {
   }
 
   /**
+   * Set the organization identity to an existing identity object.
+   * @param identityId the STIX ID of the identity to use as the organization identity
+   * @returns {Observable<any>} the update response
+   */
+  public setOrganizationIdentityRef(identityId: string): Observable<any> {
+    return this.http
+      .post(`${this.apiUrl}/config/organization-identity`, { id: identityId })
+      .pipe(
+        tap(this.handleSuccess('Organization Identity Updated')),
+        catchError(this.handleError_raise<any>()),
+        share()
+      );
+  }
+
+  /**
    * Get the organization namespace configurations
    * @returns {Observable<Namespace>} the organization namespace configurations
    */
@@ -2582,6 +2623,37 @@ export class RestApiConnectorService extends ApiConnector {
         }),
         catchError(this.handleError_raise<any>()),
         share() // multicast so that multiple subscribers don't trigger the call twice. THIS MUST BE THE LAST LINE OF THE PIPE
+      );
+  }
+
+  /**
+   * Get whether protected MITRE identity writes are enabled.
+   * @returns {Observable<MitreIdentityWrites>} the MITRE identity write setting
+   */
+  public getMitreIdentityWrites(): Observable<MitreIdentityWrites> {
+    return this.http
+      .get<MitreIdentityWrites>(`${this.apiUrl}/config/mitre-identity-writes`)
+      .pipe(
+        tap(_ => logger.log('retrieved MITRE identity write setting')),
+        catchError(
+          this.handleError_continue<MitreIdentityWrites>({ enabled: false })
+        ),
+        share()
+      );
+  }
+
+  /**
+   * Set whether protected MITRE identity writes are enabled.
+   * @param enabled true if protected MITRE identity writes should be enabled
+   * @returns {Observable<any>} the update response
+   */
+  public setMitreIdentityWrites(enabled: boolean): Observable<any> {
+    return this.http
+      .post(`${this.apiUrl}/config/mitre-identity-writes`, { enabled })
+      .pipe(
+        tap(this.handleSuccess('MITRE Identity Write Setting Updated')),
+        catchError(this.handleError_raise<any>()),
+        share()
       );
   }
 

--- a/src/app/services/editor/editor.service.ts
+++ b/src/app/services/editor/editor.service.ts
@@ -3,11 +3,14 @@ import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { SidebarService } from '../sidebar/sidebar.service';
 import { ConfirmationDialogComponent } from 'src/app/components/confirmation-dialog/confirmation-dialog.component';
 import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { AuthenticationService } from '../connectors/authentication/authentication.service';
 import { RestApiConnectorService } from '../connectors/rest-api/rest-api-connector.service';
 import { map } from 'rxjs/operators';
-import { forkJoin, Observable } from 'rxjs';
+import { forkJoin, Observable, of } from 'rxjs';
 import { Relationship } from 'src/app/classes/stix/relationship';
+
+const MITRE_IDENTITY_STIX_ID = 'identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5';
 
 @Injectable({
   providedIn: 'root',
@@ -47,7 +50,8 @@ export class EditorService {
     private sidebarService: SidebarService,
     private authenticationService: AuthenticationService,
     private apiService: RestApiConnectorService,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private snackbar: MatSnackBar
   ) {
     this.router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
@@ -62,7 +66,7 @@ export class EditorService {
           editable.length > 0 &&
           editable.every(x => x) &&
           this.authenticationService.canEdit(attackType);
-        this.hasWorkflow = attackType !== 'home';
+        this.hasWorkflow = attackType !== 'home' && this.type !== 'identity';
         if (!(this.editable && this.hasWorkflow))
           this.sidebarService.currentTab = 'search';
         this.sidebarService.setEnabled(
@@ -104,13 +108,50 @@ export class EditorService {
       }
     });
     this.route.queryParams.subscribe(params => {
-      this.editing = params['editing'] && this.authenticationService.canEdit();
+      const editingRequested =
+        params['editing'] && this.authenticationService.canEdit();
+      if (!editingRequested) {
+        this.editing = false;
+        return;
+      }
+
+      this.canEditCurrentObject().subscribe(canEdit => {
+        this.editing = canEdit;
+        if (!canEdit) this.blockProtectedMitreIdentityEdit();
+      });
     });
   }
 
   public startEditing() {
-    if (this.editable)
-      this.router.navigate([], { queryParams: { editing: true } });
+    if (this.editable) {
+      this.canEditCurrentObject().subscribe(canEdit => {
+        if (canEdit)
+          this.router.navigate([], { queryParams: { editing: true } });
+        else this.blockProtectedMitreIdentityEdit();
+      });
+    }
+  }
+
+  private canEditCurrentObject(): Observable<boolean> {
+    if (!this.isProtectedMitreIdentityRoute()) return of(true);
+
+    return this.apiService
+      .getMitreIdentityWrites()
+      .pipe(map(config => config.enabled));
+  }
+
+  private isProtectedMitreIdentityRoute(): boolean {
+    return this.type === 'identity' && this.stixId === MITRE_IDENTITY_STIX_ID;
+  }
+
+  private blockProtectedMitreIdentityEdit(): void {
+    this.editing = false;
+    this.router.navigate([], { queryParams: {}, replaceUrl: true });
+    this.snackbar.open(
+      'MITRE identity edits are disabled by system configuration.',
+      'dismiss',
+      { duration: 4000, panelClass: 'warn' }
+    );
   }
 
   public stopEditing() {

--- a/src/app/views/dashboard-page/org-settings-page/org-settings-page.component.html
+++ b/src/app/views/dashboard-page/org-settings-page/org-settings-page.component.html
@@ -28,41 +28,42 @@
       </div>
     </div>
     <div
-      *ngIf="organizationIdentity; else loadingIdentity"
+      *ngIf="organizationIdentity && organizationIdentities; else loadingIdentity"
       class="identity-edit grid">
       <hr />
       <div class="row">
         <div class="col narrow vertical-center identity-icon">
           <app-identity-property
             [config]="{
-              object: { identity: organizationIdentity },
+              object: { identity: selectedOrganizationIdentity },
               field: 'identity',
             }"></app-identity-property>
         </div>
         <div class="col">
           <mat-form-field appearance="outline">
-            <mat-label>organization name</mat-label>
-            <input matInput required [(ngModel)]="organizationIdentity.name" />
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col">
-          <mat-form-field appearance="outline">
-            <mat-label>organization description</mat-label>
-            <input matInput [(ngModel)]="organizationIdentity.description" />
-            <mat-hint>this field can be left blank if desired</mat-hint>
+            <mat-label>organization identity</mat-label>
+            <mat-select required [(ngModel)]="selectedOrganizationIdentityId">
+              <mat-option
+                *ngFor="let identity of organizationIdentities"
+                [value]="identity.stixID">
+                {{ identity.name || identity.stixID }}
+              </mat-option>
+            </mat-select>
+            <mat-hint>Select an existing identity object</mat-hint>
           </mat-form-field>
         </div>
       </div>
       <div class="row">
         <div class="col center">
           <div>
+            <button mat-button routerLink="/identity" class="text-label">
+              manage identities
+            </button>
             <button
               mat-stroked-button
               (click)="saveIdentity()"
               class="text-label"
-              [disabled]="organizationIdentity.name.length == 0">
+              [disabled]="isIdentityUnchanged">
               save
             </button>
           </div>
@@ -149,6 +150,40 @@
       </div>
     </div>
   </div>
+
+  <div *ngIf="hasMitreIdentity" class="view-page grid spacing-20">
+    <div class="row">
+      <div class="col">
+        <h2>MITRE Identity Writes</h2>
+      </div>
+    </div>
+    <div
+      *ngIf="mitreIdentityWrites; else loadingMitreIdentityWrites"
+      class="identity-edit grid spacing-16">
+      <hr />
+      <div class="mitre-identity-write-setting">
+        <p>
+          Enable this only when this Workbench instance is allowed to create or
+          update the protected MITRE Corporation identity object.
+        </p>
+        <div class="mitre-identity-write-controls">
+          <mat-slide-toggle
+            [(ngModel)]="mitreIdentityWrites.enabled"
+            [class.toggle-enabled]="mitreIdentityWrites.enabled"
+            [class.toggle-disabled]="!mitreIdentityWrites.enabled">
+            {{ mitreIdentityWrites.enabled ? 'enabled' : 'disabled' }}
+          </mat-slide-toggle>
+          <button
+            mat-stroked-button
+            (click)="saveMitreIdentityWrites()"
+            class="text-label"
+            [disabled]="isMitreIdentityWritesUnchanged">
+            save
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
   <ng-template #loadingIdentity>
     <app-loading-overlay
       message="loading organization identity"></app-loading-overlay>
@@ -156,5 +191,9 @@
   <ng-template #loadingNamespace>
     <app-loading-overlay
       message="loading organization namespace"></app-loading-overlay>
+  </ng-template>
+  <ng-template #loadingMitreIdentityWrites>
+    <app-loading-overlay
+      message="loading MITRE identity write setting"></app-loading-overlay>
   </ng-template>
 </div>

--- a/src/app/views/dashboard-page/org-settings-page/org-settings-page.component.scss
+++ b/src/app/views/dashboard-page/org-settings-page/org-settings-page.component.scss
@@ -9,3 +9,57 @@
 hr {
   margin-bottom: 30px;
 }
+
+.mitre-identity-write-setting {
+  align-items: center;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+
+  p {
+    margin: 0;
+    max-width: 760px;
+  }
+}
+
+.mitre-identity-write-controls {
+  align-items: center;
+  display: flex;
+  flex-shrink: 0;
+  gap: 16px;
+}
+
+.mitre-identity-write-controls .mat-mdc-slide-toggle.toggle-enabled {
+  --mdc-switch-selected-focus-handle-color: #ffffff;
+  --mdc-switch-selected-focus-state-layer-color: #2e7d32;
+  --mdc-switch-selected-focus-track-color: #2e7d32;
+  --mdc-switch-selected-handle-color: #ffffff;
+  --mdc-switch-selected-hover-handle-color: #ffffff;
+  --mdc-switch-selected-hover-state-layer-color: #2e7d32;
+  --mdc-switch-selected-hover-track-color: #2e7d32;
+  --mdc-switch-selected-pressed-handle-color: #ffffff;
+  --mdc-switch-selected-pressed-state-layer-color: #2e7d32;
+  --mdc-switch-selected-pressed-track-color: #2e7d32;
+  --mdc-switch-selected-track-color: #2e7d32;
+}
+
+.mitre-identity-write-controls .mat-mdc-slide-toggle.toggle-disabled {
+  --mdc-switch-unselected-focus-handle-color: #ffffff;
+  --mdc-switch-unselected-focus-state-layer-color: #c62828;
+  --mdc-switch-unselected-focus-track-color: #c62828;
+  --mdc-switch-unselected-handle-color: #ffffff;
+  --mdc-switch-unselected-hover-handle-color: #ffffff;
+  --mdc-switch-unselected-hover-state-layer-color: #c62828;
+  --mdc-switch-unselected-hover-track-color: #c62828;
+  --mdc-switch-unselected-pressed-handle-color: #ffffff;
+  --mdc-switch-unselected-pressed-state-layer-color: #c62828;
+  --mdc-switch-unselected-pressed-track-color: #c62828;
+  --mdc-switch-unselected-track-color: #c62828;
+}
+
+@media (max-width: 760px) {
+  .mitre-identity-write-setting {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/src/app/views/dashboard-page/org-settings-page/org-settings-page.component.spec.ts
+++ b/src/app/views/dashboard-page/org-settings-page/org-settings-page.component.spec.ts
@@ -7,6 +7,7 @@ import { RestApiConnectorService } from 'src/app/services/connectors/rest-api/re
 import {
   createMockRestApiConnector,
   createAsyncObservable,
+  createPaginatedResponse,
 } from 'src/app/testing/mocks/rest-api-connector.mock';
 
 describe('OrgSettingsPageComponent', () => {
@@ -16,6 +17,7 @@ describe('OrgSettingsPageComponent', () => {
   beforeEach(async () => {
     const mockRestApiConnector = createMockRestApiConnector({
       getOrganizationIdentity: () => createAsyncObservable({}),
+      getAllIdentities: () => createAsyncObservable(createPaginatedResponse()),
       getOrganizationNamespace: () =>
         createAsyncObservable({ prefix: '', range_start: undefined }),
     });

--- a/src/app/views/dashboard-page/org-settings-page/org-settings-page.component.ts
+++ b/src/app/views/dashboard-page/org-settings-page/org-settings-page.component.ts
@@ -1,9 +1,13 @@
 import { Component, OnInit } from '@angular/core';
+import { forkJoin } from 'rxjs';
 import { Identity } from 'src/app/classes/stix/identity';
 import {
+  MitreIdentityWrites,
   Namespace,
   RestApiConnectorService,
 } from 'src/app/services/connectors/rest-api/rest-api-connector.service';
+
+const MITRE_IDENTITY_STIX_ID = 'identity--c78cb6e5-0c4b-4611-8297-d1b8b55e40b5';
 
 @Component({
   selector: 'app-org-settings-page',
@@ -13,7 +17,11 @@ import {
 })
 export class OrgSettingsPageComponent implements OnInit {
   public organizationIdentity: Identity;
+  public organizationIdentities: Identity[];
+  public selectedOrganizationIdentityId: string;
   public organizationNamespace: Namespace;
+  public mitreIdentityWrites: MitreIdentityWrites;
+  private savedMitreIdentityWritesEnabled: boolean;
   public idRegex = `^([A-Za-z])*$`;
   public rangeRegex = `^([0-9]){1,4}$`;
 
@@ -29,11 +37,58 @@ export class OrgSettingsPageComponent implements OnInit {
     );
   }
 
+  public get selectedOrganizationIdentity(): Identity {
+    return this.organizationIdentities?.find(
+      identity => identity.stixID === this.selectedOrganizationIdentityId
+    );
+  }
+
+  public get isIdentityUnchanged(): boolean {
+    return (
+      !this.selectedOrganizationIdentityId ||
+      this.selectedOrganizationIdentityId === this.organizationIdentity?.stixID
+    );
+  }
+
+  public get isMitreIdentityWritesUnchanged(): boolean {
+    return (
+      !this.mitreIdentityWrites ||
+      this.mitreIdentityWrites.enabled === this.savedMitreIdentityWritesEnabled
+    );
+  }
+
+  public get hasMitreIdentity(): boolean {
+    return (
+      this.organizationIdentities?.some(
+        identity => identity.stixID === MITRE_IDENTITY_STIX_ID
+      ) ?? false
+    );
+  }
+
   constructor(private restAPIConnector: RestApiConnectorService) {}
 
   ngOnInit(): void {
-    const idSub = this.restAPIConnector.getOrganizationIdentity().subscribe({
-      next: identity => (this.organizationIdentity = identity),
+    const idSub = forkJoin({
+      identity: this.restAPIConnector.getOrganizationIdentity(),
+      identities: this.restAPIConnector.getAllIdentities(),
+    }).subscribe({
+      next: ({ identity, identities }) => {
+        this.organizationIdentity = identity;
+        this.organizationIdentities = identities.data as Identity[];
+        if (
+          !this.organizationIdentities.some(
+            organizationIdentity =>
+              organizationIdentity.stixID === identity.stixID
+          )
+        ) {
+          this.organizationIdentities.push(identity);
+        }
+        this.organizationIdentities.sort((a, b) =>
+          (a.name || a.stixID).localeCompare(b.name || b.stixID)
+        );
+        this.selectedOrganizationIdentityId = identity.stixID;
+        if (this.hasMitreIdentity) this.loadMitreIdentityWrites();
+      },
       complete: () => idSub.unsubscribe(),
     });
 
@@ -52,6 +107,18 @@ export class OrgSettingsPageComponent implements OnInit {
       });
   }
 
+  private loadMitreIdentityWrites(): void {
+    const mitreIdentityWritesSub = this.restAPIConnector
+      .getMitreIdentityWrites()
+      .subscribe({
+        next: mitreIdentityWrites => {
+          this.mitreIdentityWrites = mitreIdentityWrites;
+          this.savedMitreIdentityWritesEnabled = mitreIdentityWrites.enabled;
+        },
+        complete: () => mitreIdentityWritesSub.unsubscribe(),
+      });
+  }
+
   onBlur(): void {
     if (!this.isNOU(this.organizationNamespace.range_start)) {
       this.organizationNamespace.range_start =
@@ -61,9 +128,10 @@ export class OrgSettingsPageComponent implements OnInit {
 
   saveIdentity(): void {
     const subscription = this.restAPIConnector
-      .postIdentity(this.organizationIdentity)
+      .setOrganizationIdentityRef(this.selectedOrganizationIdentityId)
       .subscribe({
-        next: identity => (this.organizationIdentity = identity),
+        next: () =>
+          (this.organizationIdentity = this.selectedOrganizationIdentity),
         complete: () => subscription.unsubscribe(),
       });
   }
@@ -73,6 +141,17 @@ export class OrgSettingsPageComponent implements OnInit {
       .setOrganizationNamespace(this.organizationNamespace)
       .subscribe({
         next: namespace => (this.organizationNamespace = namespace),
+        complete: () => subscription.unsubscribe(),
+      });
+  }
+
+  saveMitreIdentityWrites(): void {
+    const subscription = this.restAPIConnector
+      .setMitreIdentityWrites(this.mitreIdentityWrites.enabled)
+      .subscribe({
+        next: () =>
+          (this.savedMitreIdentityWritesEnabled =
+            this.mitreIdentityWrites.enabled),
         complete: () => subscription.unsubscribe(),
       });
   }

--- a/src/app/views/landing-page/landing-page.component.ts
+++ b/src/app/views/landing-page/landing-page.component.ts
@@ -16,6 +16,9 @@ import { stixRoutes } from '../../app-routing-stix.module';
   standalone: false,
 })
 export class LandingPageComponent implements OnInit, OnDestroy {
+  private readonly placeholderIdentityName = 'Placeholder Organization Identity';
+  private readonly placeholderIdentityReminderKey =
+    'attack-workbench.placeholder-organization-identity-reminder-dismissed';
   private loginSubscription: Subscription;
   public pendingUsers;
   public routes: any[] = [];
@@ -71,15 +74,16 @@ export class LandingPageComponent implements OnInit, OnDestroy {
 
   // bug the admin about editing their organization identity
   private openOrgIdentityDialog(): void {
+    if (localStorage.getItem(this.placeholderIdentityReminderKey) === 'true') {
+      return;
+    }
+
     if (this.authenticationService.isAuthorized([Role.ADMIN])) {
       const subscription = this.restApiConnector
         .getOrganizationIdentity()
         .subscribe({
           next: identity => {
-            if (
-              identity &&
-              identity.name == 'Placeholder Organization Identity'
-            ) {
+            if (identity && identity.name == this.placeholderIdentityName) {
               const prompt = this.dialog.open(ConfirmationDialogComponent, {
                 maxWidth: '35em',
                 data: {
@@ -87,13 +91,23 @@ export class LandingPageComponent implements OnInit, OnDestroy {
                     '### Your organization identity has not yet been set.\n\nYour organization identity is used for attribution of edits you make to objects in the knowledge base and is attached to published collections. Currently, a placeholder is being used.\n\nUpdate your organization identity now?',
                   yes_suffix: 'edit my identity now',
                   no_suffix: 'edit my identity later',
+                  alternate_label: 'No, and stop reminding me',
+                  alternate_value: 'dismiss',
                 },
                 autoFocus: false, // prevents auto focus on buttons
               });
               const prompt_subscription = prompt.afterClosed().subscribe({
                 next: prompt_result => {
-                  if (prompt_result)
-                    this.router.navigate(['/dashboard/org-settings']);
+                  if (prompt_result === true) {
+                    this.router.navigate(['/identity', identity.stixID], {
+                      queryParams: { editing: true },
+                    });
+                  } else if (prompt_result === 'dismiss') {
+                    localStorage.setItem(
+                      this.placeholderIdentityReminderKey,
+                      'true'
+                    );
+                  }
                 },
                 complete: () => {
                   prompt_subscription.unsubscribe();

--- a/src/app/views/stix/identity-view/identity-view.component.html
+++ b/src/app/views/stix/identity-view/identity-view.component.html
@@ -1,0 +1,98 @@
+<div class="identity-view view-page grid spacing-16">
+  <div class="row">
+    <div class="col">
+      <app-name-property
+        [config]="{
+          mode: config.mode,
+          object: config.object,
+        }"></app-name-property>
+      <app-subheading
+        [config]="config"
+        (onOpenHistory)="openHistory()"
+        (onOpenNotes)="openNotes()"></app-subheading>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
+      <app-string-property
+        class="grow-to-row"
+        [config]="{
+          mode: config.mode,
+          object: config.object,
+          field: 'identity_class',
+          label: 'identity class',
+          required: true,
+          editType: 'select',
+        }"></app-string-property>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
+      <app-list-property
+        class="grow-to-row"
+        [config]="{
+          mode: config.mode,
+          object: config.object,
+          field: 'roles',
+          editType: 'any',
+        }"></app-list-property>
+    </div>
+    <div class="col">
+      <app-list-property
+        class="grow-to-row"
+        [config]="{
+          mode: config.mode,
+          object: config.object,
+          field: 'sectors',
+          editType: 'select',
+        }"></app-list-property>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
+      <app-string-property
+        class="grow-to-row"
+        [config]="{
+          mode: config.mode,
+          object: config.object,
+          field: 'contact',
+          label: 'contact information',
+        }"></app-string-property>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
+      <app-descriptive-property
+        [config]="{
+          mode: config.mode,
+          object: config.object,
+          field: 'description',
+          firstParagraphOnly: false,
+          referencesField: 'external_references',
+          label: 'Description',
+        }"></app-descriptive-property>
+    </div>
+  </div>
+  <div
+    *ngIf="
+      identity.external_references.list().length > 0 ||
+      previous?.external_references.list().length > 0 ||
+      editing
+    ">
+    <div class="row">
+      <div class="col">
+        <h2 class="section-header">References</h2>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <app-external-references-property
+          [config]="{
+            mode: config.mode,
+            object: config.object,
+            referencesField: 'external_references',
+          }"></app-external-references-property>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/views/stix/identity-view/identity-view.component.ts
+++ b/src/app/views/stix/identity-view/identity-view.component.ts
@@ -1,0 +1,32 @@
+import { Component, OnInit } from '@angular/core';
+import { Identity } from 'src/app/classes/stix';
+import { AuthenticationService } from 'src/app/services/connectors/authentication/authentication.service';
+import { RestApiConnectorService } from 'src/app/services/connectors/rest-api/rest-api-connector.service';
+import { StixViewPage } from '../stix-view-page';
+
+@Component({
+  selector: 'app-identity-view',
+  templateUrl: './identity-view.component.html',
+  standalone: false,
+})
+export class IdentityViewComponent extends StixViewPage implements OnInit {
+  public get identity(): Identity {
+    return this.configCurrentObject as Identity;
+  }
+  public get previous(): Identity {
+    return this.configPreviousObject as Identity;
+  }
+
+  constructor(
+    authenticationService: AuthenticationService,
+    private restApiConnector: RestApiConnectorService
+  ) {
+    super(authenticationService);
+  }
+
+  ngOnInit(): void {
+    if (this.identity.firstInitialized) {
+      this.identity.setDefaultMarkingDefinitions(this.restApiConnector);
+    }
+  }
+}

--- a/src/app/views/stix/stix-page/stix-page.component.html
+++ b/src/app/views/stix/stix-page/stix-page.component.html
@@ -50,6 +50,9 @@
       <app-asset-view
         *ngIf="objectType === 'asset'"
         [config]="buildConfig()"></app-asset-view>
+      <app-identity-view
+        *ngIf="objectType === 'identity'"
+        [config]="buildConfig()"></app-identity-view>
       <app-marking-definition-view
         *ngIf="objectType === 'marking-definition'"
         [config]="buildConfig()"></app-marking-definition-view>

--- a/src/app/views/stix/stix-page/stix-page.component.ts
+++ b/src/app/views/stix/stix-page/stix-page.component.ts
@@ -112,6 +112,7 @@ export class StixPageComponent implements OnInit, OnDestroy {
               ? this.oldAnalytics
               : undefined,
           versionAlreadyIncremented: versionChanged,
+          showWorkflow: this.editorService.hasWorkflow,
         },
         autoFocus: false, // prevent auto focus on form field
       });
@@ -339,6 +340,8 @@ export class StixPageComponent implements OnInit, OnDestroy {
         );
       else if (this.objectType == 'asset')
         objects$ = this.restApiService.getAsset(objectStixID);
+      else if (this.objectType == 'identity')
+        objects$ = this.restApiService.getIdentity(objectStixID);
       else if (this.objectType == 'marking-definition')
         objects$ = this.restApiService.getMarkingDefinition(objectStixID);
       const subscription = objects$.subscribe({


### PR DESCRIPTION
There is now a new button to semi-permanently ignore/hide the reminder modal to edit the placeholder identity:

<img width="623" height="338" alt="SCR-20260624-inpz" src="https://github.com/user-attachments/assets/899fd99d-ff99-499b-ac1c-681087cdec53" />

---

When you click **No, and stop reminding me**, the frontend stores a key in localStorage to remember the user's preference. 

(I felt that a stateful user-specific config in the database would be overkill).

<img width="780" height="235" alt="SCR-20260624-inyf" src="https://github.com/user-attachments/assets/5fd3630c-bd1a-4420-b048-ff5eae8a2b17" />

---

If you click **Yes, edit my identity now**, the user is redirected to the edit view for the placeholder identity, as opposed to the `/org-settings` section. This will make sense why in a moment.

<img width="1071" height="1061" alt="SCR-20260624-iohm" src="https://github.com/user-attachments/assets/2b829137-46df-45a0-9abf-06b76c2bd473" />

---

The global organization identity is now a drop-down selector!

Identities are now first-class objects in Workbench. They can be viewed, created, edited, and deleted, just like any other STIX object.

<img width="1118" height="845" alt="SCR-20260624-ipew" src="https://github.com/user-attachments/assets/41195c64-472d-4960-9275-40340a0d633c" />

<img width="804" height="165" alt="SCR-20260624-iphc" src="https://github.com/user-attachments/assets/96c349cc-dbca-44b9-a54d-4a6b589f2feb" />

<img width="1071" height="1061" alt="SCR-20260624-iojn" src="https://github.com/user-attachments/assets/3a75726d-0cf1-493e-94c5-49e46d3344a2" />

<img width="1118" height="845" alt="SCR-20260624-irbb" src="https://github.com/user-attachments/assets/151ab36a-125a-481f-a5ce-fc8b16c33c23" />

---

By default, the MITRE identity is protected. Workbench blocks access to the `?editing=true` view, and the REST API will reject all POST, PUT, and DELETE requests on the MITRE identity specifically.

<img width="1071" height="1061" alt="SCR-20260624-iopj" src="https://github.com/user-attachments/assets/5af0eccf-f272-414b-b372-7462fefae332" />

Protecting the MITRE identity can be enabled or disabled using a new endpoint:

```json5
// POST /api/config/mitre-identity-writes
{
  "enabled": true | false
}
```

<img width="1118" height="964" alt="SCR-20260624-irjw" src="https://github.com/user-attachments/assets/210e8dbd-7506-4445-ac4b-f503a9ec4a41" />

The frontend exposes a toggle for this — this toggle/section will _only_ appear on the frontend if the MITRE identity actually exists in the database.

<img width="1118" height="845" alt="SCR-20260624-ipbn" src="https://github.com/user-attachments/assets/83eaeb23-903a-4bc0-828f-4cb97c19778b" />

Lastly, the system will block you from deleting an identity if it is the organization identity, or more specifically, if any **latest, active objects** reference it in their `created_by_ref` or `x_mitre_modified_by_ref` fields.

---

1. This endpoint maps to a new key in the `systemconfigurations` collection/entity, called `mitre_identity_writes_enabled`.

2. Note that the `organization_identity_ref` is no longer sticky. Whereas before, it was set to the `stix.id` of the randomly generated `Placeholder Organization Identity` object; it can now be changed to a completely different identity using the drop-down selector.

<img width="1532" height="1061" alt="SCR-20260624-iqcn" src="https://github.com/user-attachments/assets/eee79c30-e5f4-425e-97ce-65b9cc351bdd" />

---

Lastly, there is a new dashboard for managing the ADM validation bypass rules:

<img width="1488" height="1104" alt="SCR-20260624-kgup" src="https://github.com/user-attachments/assets/44edffd7-8693-4580-b22b-a42644b84387" />

<img width="1488" height="1104" alt="SCR-20260624-kgxr" src="https://github.com/user-attachments/assets/f0803be6-8637-436f-80a5-d345d3d81cf0" />

<img width="1488" height="1104" alt="SCR-20260624-khbo" src="https://github.com/user-attachments/assets/f2600755-d731-4c69-a7c3-6808b4d3d100" />

---

There is a complementary set of changes on the backend: https://github.com/center-for-threat-informed-defense/attack-workbench-rest-api/pull/481