### PR TITLE
Fix/release tracks api contract

### DIFF
--- a/src/app/classes/release-tracks/api.ts
+++ b/src/app/classes/release-tracks/api.ts
@@ -35,7 +35,10 @@ export interface UpdateMetadataPayload {
 }
 
 export interface UpdateContentsPayload {
-  x_mitre_contents: string[];
+  x_mitre_contents: Array<{
+    obj_ref: string;
+    obj_modified: string;
+  }>;
 }
 
 export type ReleasePayload =

--- a/src/app/classes/release-tracks/api.ts
+++ b/src/app/classes/release-tracks/api.ts
@@ -56,9 +56,14 @@ export interface ReviewPayload {
   object_refs?: StixObjectRef[];
 }
 
+export interface PromoteQuarantinePayload {
+  object_ref: string;
+  object_modified: string;
+}
+
 export interface ReleaseTrackSnapshotOptions {
   format?: ExportFormatType;
-  include?: 'members' | 'staged' | 'candidates' | 'all';
+  include?: 'members' | 'staged' | 'candidates' | 'quarantine' | 'all';
   state?: string | string[];
   stixVersion?: '2.0' | '2.1';
   includeToc?: boolean;

--- a/src/app/classes/release-tracks/api.ts
+++ b/src/app/classes/release-tracks/api.ts
@@ -35,10 +35,10 @@ export interface UpdateMetadataPayload {
 }
 
 export interface UpdateContentsPayload {
-  x_mitre_contents: Array<{
+  x_mitre_contents: {
     obj_ref: string;
     obj_modified: string;
-  }>;
+  }[];
 }
 
 export type ReleasePayload =
@@ -88,8 +88,7 @@ export interface ReleasePreviewSummaryBase {
   conflicts: any[];
 }
 
-export interface StandardReleasePreviewSummary
-  extends ReleasePreviewSummaryBase {
+export interface StandardReleasePreviewSummary extends ReleasePreviewSummaryBase {
   type: ReleaseTrackType.Standard;
   before: {
     members_count: number;
@@ -141,15 +140,13 @@ interface ReleaseTrackSnapshotHistoryBase {
   members_count: number;
 }
 
-export interface StandardReleaseTrackSnapshotHistoryItem
-  extends ReleaseTrackSnapshotHistoryBase {
+export interface StandardReleaseTrackSnapshotHistoryItem extends ReleaseTrackSnapshotHistoryBase {
   type: ReleaseTrackType.Standard;
   staged_count: number;
   candidates_count: number;
 }
 
-export interface VirtualReleaseTrackSnapshotHistoryItem
-  extends ReleaseTrackSnapshotHistoryBase {
+export interface VirtualReleaseTrackSnapshotHistoryItem extends ReleaseTrackSnapshotHistoryBase {
   type: ReleaseTrackType.Virtual;
   quarantine_count: number;
 }

--- a/src/app/classes/release-tracks/api.ts
+++ b/src/app/classes/release-tracks/api.ts
@@ -1,7 +1,11 @@
 import type { WorkflowStatusType } from 'src/app/utils/types';
 import type { Composition } from './composition';
 import type { ReleaseTrackConfig } from './config';
-import type { ExportFormatType, ReleaseTrackType } from './enums';
+import {
+  ReleaseTrackType,
+  type ExportFormatType,
+  type ReleasePreviewFormatType,
+} from './enums';
 import type { SnapshotSchedule } from './release-track';
 
 export type StixObjectRef = string | { id: string; modified?: string };
@@ -34,11 +38,10 @@ export interface UpdateContentsPayload {
   x_mitre_contents: string[];
 }
 
-export interface BumpPayload {
-  type?: 'major' | 'minor';
-  version?: string;
-  dry_run?: boolean;
-}
+export type ReleasePayload =
+  | { increment: 'major' | 'minor'; version?: never }
+  | { increment?: never; version: string }
+  | { increment?: undefined; version?: undefined };
 
 export interface ClonePayload {
   name?: string;
@@ -53,11 +56,67 @@ export interface ReviewPayload {
 export interface ReleaseTrackSnapshotOptions {
   format?: ExportFormatType;
   include?: 'members' | 'staged' | 'candidates' | 'all';
-  releases?: 'only';
-  version?: string;
-  versions?: 'all';
-  [key: string]: any;
+  state?: string | string[];
+  stixVersion?: '2.0' | '2.1';
+  includeToc?: boolean;
 }
+
+export type ReleasePreviewOptions = ReleasePayload & {
+  format?: ReleasePreviewFormatType;
+};
+
+export interface ReleasePreviewSummaryBase {
+  track_id: string;
+  type: ReleaseTrackType;
+  source_snapshot_modified: string;
+  version: string;
+  releasable: boolean;
+  conflicts: any[];
+}
+
+export interface StandardReleasePreviewSummary
+  extends ReleasePreviewSummaryBase {
+  type: ReleaseTrackType.Standard;
+  before: {
+    members_count: number;
+    staged_count: number;
+    candidates_count: number;
+  };
+  after: {
+    members_count: number;
+    staged_count: number;
+    candidates_count: number;
+  };
+  changes: {
+    promoted_count: number;
+  };
+}
+
+export interface VirtualReleasePreviewSummary extends ReleasePreviewSummaryBase {
+  type: ReleaseTrackType.Virtual;
+  previous_release: {
+    version: string;
+    modified: string;
+  } | null;
+  before: {
+    members_count: number;
+    quarantine_count: number;
+  };
+  after: {
+    members_count: number;
+    quarantine_count: number;
+  };
+  changes: {
+    new_count: number;
+    updated_count: number;
+    removed_count: number;
+    quarantined_count: number;
+  };
+}
+
+export type ReleasePreviewSummary =
+  | StandardReleasePreviewSummary
+  | VirtualReleasePreviewSummary;
 
 export interface ReleaseTrackSnapshotHistoryItem {
   id?: string;

--- a/src/app/classes/release-tracks/api.ts
+++ b/src/app/classes/release-tracks/api.ts
@@ -61,6 +61,12 @@ export interface ReleaseTrackSnapshotOptions {
   includeToc?: boolean;
 }
 
+export interface SnapshotHistoryOptions {
+  tagged?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
 export type ReleasePreviewOptions = ReleasePayload & {
   format?: ReleasePreviewFormatType;
 };
@@ -118,35 +124,28 @@ export type ReleasePreviewSummary =
   | StandardReleasePreviewSummary
   | VirtualReleasePreviewSummary;
 
-export interface ReleaseTrackSnapshotHistoryItem {
-  id?: string;
-  modified?: string | Date;
-  version?: string | null;
-  created?: string | Date;
-  tagged_at?: string | Date;
-  snapshot_id?: string | Date;
-  members?: any[];
-  staged?: any[];
-  candidates?: any[];
-  contents?: {
-    members?: any[];
-    staged?: any[];
-    candidates?: any[];
-    [key: string]: any;
-  };
-  summary?: {
-    members_count?: number;
-    added_count?: number;
-    modified_count?: number;
-    promoted_count?: number;
-    [key: string]: any;
-  };
-  stix?: {
-    id?: string;
-    modified?: string | Date;
-    x_mitre_version?: string | null;
-    x_mitre_contents?: any[];
-    [key: string]: any;
-  };
-  [key: string]: any;
+interface ReleaseTrackSnapshotHistoryBase {
+  id: string;
+  modified: string;
+  version: string | null;
+  name: string;
+  description?: string;
+  members_count: number;
 }
+
+export interface StandardReleaseTrackSnapshotHistoryItem
+  extends ReleaseTrackSnapshotHistoryBase {
+  type: ReleaseTrackType.Standard;
+  staged_count: number;
+  candidates_count: number;
+}
+
+export interface VirtualReleaseTrackSnapshotHistoryItem
+  extends ReleaseTrackSnapshotHistoryBase {
+  type: ReleaseTrackType.Virtual;
+  quarantine_count: number;
+}
+
+export type ReleaseTrackSnapshotHistoryItem =
+  | StandardReleaseTrackSnapshotHistoryItem
+  | VirtualReleaseTrackSnapshotHistoryItem;

--- a/src/app/classes/release-tracks/api.ts
+++ b/src/app/classes/release-tracks/api.ts
@@ -34,13 +34,6 @@ export interface UpdateMetadataPayload {
   object_marking_refs?: string[];
 }
 
-export interface UpdateContentsPayload {
-  x_mitre_contents: {
-    obj_ref: string;
-    obj_modified: string;
-  }[];
-}
-
 export type ReleasePayload =
   | { increment: 'major' | 'minor'; version?: never }
   | { increment?: never; version: string }
@@ -128,8 +121,7 @@ export interface VirtualReleasePreviewSummary extends ReleasePreviewSummaryBase 
 }
 
 export type ReleasePreviewSummary =
-  | StandardReleasePreviewSummary
-  | VirtualReleasePreviewSummary;
+  StandardReleasePreviewSummary | VirtualReleasePreviewSummary;
 
 interface ReleaseTrackSnapshotHistoryBase {
   id: string;

--- a/src/app/classes/release-tracks/enums.ts
+++ b/src/app/classes/release-tracks/enums.ts
@@ -53,7 +53,6 @@ export const DEDUPLICATION_STRATEGY_OPTIONS: DeduplicationStrategyType[] =
 // -----------------------------------------------------------------------------
 
 export enum ExportFormat {
-  Snapshot = 'snapshot',
   Bundle = 'bundle',
   Workbench = 'workbench',
   FileSystemStore = 'filesystemstore',
@@ -64,6 +63,15 @@ export type ExportFormatType = EnumValue<typeof ExportFormat>;
 export const EXPORT_FORMAT_OPTIONS: ExportFormatType[] = Object.values(
   ExportFormat
 ) as ExportFormatType[];
+
+export enum ReleasePreviewFormat {
+  Summary = 'summary',
+  Bundle = 'bundle',
+  Workbench = 'workbench',
+  FileSystemStore = 'filesystemstore',
+}
+
+export type ReleasePreviewFormatType = EnumValue<typeof ReleasePreviewFormat>;
 
 // -----------------------------------------------------------------------------
 // Release Track Snapshot Tiers

--- a/src/app/classes/release-tracks/snapshot.spec.ts
+++ b/src/app/classes/release-tracks/snapshot.spec.ts
@@ -64,4 +64,67 @@ describe('ReleaseTrackSnapshot', () => {
       })
     );
   });
+
+  it('should preserve latest selectors for candidate and staged revisions', () => {
+    const snapshot = new ReleaseTrackSnapshot({
+      candidates: [
+        {
+          object_ref: 'attack-pattern--candidate',
+          object_modified: 'latest',
+          object_status: 'work-in-progress',
+        },
+      ],
+      staged: [
+        {
+          object_ref: 'attack-pattern--staged',
+          object_modified: 'latest',
+          object_status: 'reviewed',
+        },
+      ],
+    });
+
+    expect(snapshot.candidates?.[0].object_modified).toBe('latest');
+    expect(snapshot.staged?.[0].object_modified).toBe('latest');
+    expect(snapshot.serialize()).toEqual(
+      expect.objectContaining({
+        candidates: [
+          expect.objectContaining({
+            object_modified: 'latest',
+          }),
+        ],
+        staged: [
+          expect.objectContaining({
+            object_modified: 'latest',
+          }),
+        ],
+      })
+    );
+  });
+
+  it('should deserialize and serialize exact workflow revision timestamps', () => {
+    const modified = '2026-01-04T00:00:00.000Z';
+    const snapshot = new ReleaseTrackSnapshot({
+      candidates: [
+        {
+          object_ref: 'attack-pattern--candidate',
+          object_modified: modified,
+          object_status: 'work-in-progress',
+        },
+      ],
+      staged: [
+        {
+          object_ref: 'attack-pattern--staged',
+          object_modified: modified,
+          object_status: 'reviewed',
+        },
+      ],
+    });
+
+    expect(snapshot.candidates?.[0].object_modified).toEqual(
+      new Date(modified)
+    );
+    expect(snapshot.staged?.[0].object_modified).toEqual(new Date(modified));
+    expect(snapshot.serialize().candidates[0].object_modified).toBe(modified);
+    expect(snapshot.serialize().staged[0].object_modified).toBe(modified);
+  });
 });

--- a/src/app/classes/release-tracks/snapshot.ts
+++ b/src/app/classes/release-tracks/snapshot.ts
@@ -120,9 +120,7 @@ export class ReleaseTrackSnapshot {
       this.staged = raw.staged.map((s: any) => ({
         ...s,
         object_ref: s.object_ref,
-        object_modified: this.deserializeWorkflowRevision(
-          s.object_modified
-        ),
+        object_modified: this.deserializeWorkflowRevision(s.object_modified),
         object_status: s.object_status,
         object_staged_at: s.object_staged_at
           ? new Date(s.object_staged_at)
@@ -135,9 +133,7 @@ export class ReleaseTrackSnapshot {
       this.candidates = raw.candidates.map((c: any) => ({
         ...c,
         object_ref: c.object_ref,
-        object_modified: this.deserializeWorkflowRevision(
-          c.object_modified
-        ),
+        object_modified: this.deserializeWorkflowRevision(c.object_modified),
         object_status: c.object_status,
         object_added_at: c.object_added_at
           ? new Date(c.object_added_at)

--- a/src/app/classes/release-tracks/snapshot.ts
+++ b/src/app/classes/release-tracks/snapshot.ts
@@ -8,6 +8,7 @@ import {
   MemberEntry,
   QuarantineEntry,
   StagedEntry,
+  WorkflowRevisionSelector,
 } from './tiers';
 
 export class ReleaseTrackSnapshot {
@@ -119,9 +120,9 @@ export class ReleaseTrackSnapshot {
       this.staged = raw.staged.map((s: any) => ({
         ...s,
         object_ref: s.object_ref,
-        object_modified: s.object_modified
-          ? new Date(s.object_modified)
-          : undefined,
+        object_modified: this.deserializeWorkflowRevision(
+          s.object_modified
+        ),
         object_status: s.object_status,
         object_staged_at: s.object_staged_at
           ? new Date(s.object_staged_at)
@@ -134,9 +135,9 @@ export class ReleaseTrackSnapshot {
       this.candidates = raw.candidates.map((c: any) => ({
         ...c,
         object_ref: c.object_ref,
-        object_modified: c.object_modified
-          ? new Date(c.object_modified)
-          : undefined,
+        object_modified: this.deserializeWorkflowRevision(
+          c.object_modified
+        ),
         object_status: c.object_status,
         object_added_at: c.object_added_at
           ? new Date(c.object_added_at)
@@ -212,18 +213,14 @@ export class ReleaseTrackSnapshot {
       })),
       staged: this.staged?.map(s => ({
         ...s,
-        object_modified: s.object_modified
-          ? (s.object_modified as any).toISOString()
-          : s.object_modified,
+        object_modified: this.serializeWorkflowRevision(s.object_modified),
         object_staged_at: s.object_staged_at
           ? (s.object_staged_at as any).toISOString()
           : s.object_staged_at,
       })),
       candidates: this.candidates?.map(c => ({
         ...c,
-        object_modified: c.object_modified
-          ? (c.object_modified as any).toISOString()
-          : c.object_modified,
+        object_modified: this.serializeWorkflowRevision(c.object_modified),
         object_added_at: c.object_added_at
           ? (c.object_added_at as any).toISOString()
           : c.object_added_at,
@@ -258,6 +255,21 @@ export class ReleaseTrackSnapshot {
   // Get the member entry for the given STIX ID
   public findMember(objectRef: string): MemberEntry | undefined {
     return this.members.find(m => m.object_ref === objectRef);
+  }
+
+  private deserializeWorkflowRevision(
+    value: string | Date | undefined
+  ): WorkflowRevisionSelector | undefined {
+    if (!value) return undefined;
+    return value === 'latest' ? 'latest' : new Date(value);
+  }
+
+  private serializeWorkflowRevision(
+    value: WorkflowRevisionSelector | undefined
+  ): string | undefined {
+    if (value === undefined) return undefined;
+    if (value === 'latest') return value;
+    return value.toISOString();
   }
 
   // Get the candidate entry for the given STIX ID

--- a/src/app/classes/release-tracks/tiers.ts
+++ b/src/app/classes/release-tracks/tiers.ts
@@ -2,7 +2,8 @@ import { WorkflowStatusType } from 'src/app/utils/types';
 import { SnapshotTier } from './enums';
 
 export type ReleaseTrackObjectTier =
-  SnapshotTier.Candidate | SnapshotTier.Staged;
+  | SnapshotTier.Candidate
+  | SnapshotTier.Staged;
 
 export type WorkflowRevisionSelector = Date | 'latest';
 

--- a/src/app/classes/release-tracks/tiers.ts
+++ b/src/app/classes/release-tracks/tiers.ts
@@ -4,6 +4,8 @@ import { SnapshotTier } from './enums';
 export type ReleaseTrackObjectTier =
   SnapshotTier.Candidate | SnapshotTier.Staged;
 
+export type WorkflowRevisionSelector = Date | 'latest';
+
 export interface TierEntryModifiedByUser {
   id?: string;
   username?: string;
@@ -25,7 +27,7 @@ export interface MemberEntry {
 
 export interface StagedEntry extends TierEntryDisplayFields {
   object_ref: string;
-  object_modified: Date;
+  object_modified: WorkflowRevisionSelector;
   object_status: WorkflowStatusType;
   object_staged_at: Date;
   object_staged_by: string;
@@ -33,7 +35,7 @@ export interface StagedEntry extends TierEntryDisplayFields {
 
 export interface CandidateEntry extends TierEntryDisplayFields {
   object_ref: string;
-  object_modified: Date;
+  object_modified: WorkflowRevisionSelector;
   object_status: WorkflowStatusType;
   object_added_at: Date;
   object_added_by: string;

--- a/src/app/services/connectors/rest-api/release-tracks.integration.spec.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.integration.spec.ts
@@ -24,23 +24,13 @@ async function probe(url: string, timeoutMs = 3000): Promise<Response> {
 
 beforeAll(async () => {
   try {
-    const res = await probe(`${apiUrl}/release-tracks`);
+    const res = await probe(`${apiUrl}/release-tracks?type=standard&limit=1`);
     if (res && res.ok) {
       serverAvailable = true;
-      // try to read and pick an id if available
       try {
         const body = await res.json().catch(() => null);
-        // server may return paginated object or array
-        if (Array.isArray(body) && body.length > 0 && body[0].id) {
-          discoveredTrackId = body[0].id;
-        } else if (
-          body &&
-          body.items &&
-          Array.isArray(body.items) &&
-          body.items.length > 0 &&
-          body.items[0].id
-        ) {
-          discoveredTrackId = body.items[0].id;
+        if (Array.isArray(body?.data) && body.data[0]?.id) {
+          discoveredTrackId = body.data[0].id;
         }
       } catch (e) {
         console.error(e);
@@ -95,7 +85,7 @@ describe('Release Tracks API integration (real server)', () => {
     }
   });
 
-  it('GET /release-tracks/:id -> getLatestSnapshot should return snapshot when tracks exist', async () => {
+  it('GET /release-tracks/:id/snapshots/latest should return the latest snapshot', async () => {
     if (!serverAvailable) {
       console.warn(
         'Skipping getLatestSnapshot test because server is unreachable'
@@ -109,7 +99,7 @@ describe('Release Tracks API integration (real server)', () => {
       return;
     }
     const res = await fetch(
-      `${apiUrl}/release-tracks/${encodeURIComponent(discoveredTrackId)}`,
+      `${apiUrl}/release-tracks/${encodeURIComponent(discoveredTrackId)}/snapshots/latest`,
       { headers: commonHeaders }
     );
     expect(res.ok).toBe(true);

--- a/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
@@ -144,6 +144,26 @@ describe('ReleaseTracksConnectorService', () => {
     expect(options.params.get('offset')).toBe('50');
   });
 
+  it('should list tracks with only supported query parameters', () => {
+    service
+      .listReleaseTracks({
+        type: 'virtual',
+        limit: 25,
+        offset: 0,
+        search: 'enterprise',
+      })
+      .subscribe();
+
+    const [url, options] = http.get.mock.calls[0];
+    expect(url).toBe(
+      `${environment.integrations.rest_api.url}/release-tracks`
+    );
+    expect(options.params.get('type')).toBe('virtual');
+    expect(options.params.get('limit')).toBe('25');
+    expect(options.params.get('offset')).toBe('0');
+    expect(options.params.get('search')).toBe('enterprise');
+  });
+
   it('should confirm the target ID when deleting a release track', () => {
     service.deleteReleaseTrack('release-track--standard').subscribe();
 

--- a/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
@@ -180,10 +180,27 @@ describe('ReleaseTracksConnectorService', () => {
       )
       .subscribe();
 
-    const [, payload, options] = http.post.mock.calls[0];
+    const [url, payload, options] = http.post.mock.calls[0];
+    expect(url).toBe(
+      `${environment.integrations.rest_api.url}/release-tracks/release-track--standard/snapshots/2026-07-23T13%3A37%3A28.000Z/contents`
+    );
     expect(payload).toEqual(body);
     expect(options.params.get('confirm_track_id')).toBe(
       'release-track--standard'
+    );
+  });
+
+  it('should encode timestamps used as snapshot path parameters', () => {
+    service
+      .retrieveSnapshotByModified(
+        'release-track--standard',
+        '2026-07-23T13:37:28.000Z'
+      )
+      .subscribe();
+
+    const [url] = http.get.mock.calls[0];
+    expect(url).toBe(
+      `${environment.integrations.rest_api.url}/release-tracks/release-track--standard/snapshots/2026-07-23T13%3A37%3A28.000Z`
     );
   });
 });

--- a/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
@@ -1,0 +1,64 @@
+import { of } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { ReleaseTracksConnectorService } from './release-tracks.service';
+
+describe('ReleaseTracksConnectorService', () => {
+  let http: {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+  let service: ReleaseTracksConnectorService;
+
+  beforeEach(() => {
+    http = {
+      get: vi.fn(() => of({})),
+      post: vi.fn(() => of({})),
+      put: vi.fn(() => of({})),
+      delete: vi.fn(() => of({})),
+    };
+    service = new ReleaseTracksConnectorService(
+      http as any,
+      { open: vi.fn() } as any
+    );
+  });
+
+  it('should create virtual snapshots through the virtual namespace', () => {
+    service
+      .createVirtualSnapshot('release-track--virtual', {
+        description: 'Scheduled draft',
+      })
+      .subscribe();
+
+    expect(http.post).toHaveBeenCalledWith(
+      `${environment.integrations.rest_api.url}/release-tracks/release-track--virtual/virtual/snapshots/create`,
+      { description: 'Scheduled draft' }
+    );
+  });
+
+  it('should update composition through the virtual namespace', () => {
+    const composition = {
+      component_tracks: [
+        {
+          track_id: 'release-track--standard',
+          resolution_strategy: 'latest_tagged' as const,
+          priority: 0,
+        },
+      ],
+    };
+
+    service
+      .updateComposition('release-track--virtual', composition)
+      .subscribe();
+
+    expect(http.put).toHaveBeenCalledWith(
+      `${environment.integrations.rest_api.url}/release-tracks/release-track--virtual/virtual/composition`,
+      composition
+    );
+  });
+
+  it('should not expose the removed virtual snapshot preview operation', () => {
+    expect((service as any).previewVirtualSnapshot).toBeUndefined();
+  });
+});

--- a/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
@@ -172,56 +172,6 @@ describe('ReleaseTracksConnectorService', () => {
     );
   });
 
-  it('should send exact revision references when replacing latest contents', () => {
-    const body = {
-      x_mitre_contents: [
-        {
-          obj_ref: 'attack-pattern--one',
-          obj_modified: '2026-07-23T13:37:28.000Z',
-        },
-      ],
-    };
-
-    service.updateContentsByLatest('release-track--standard', body).subscribe();
-
-    const [url, payload, options] = http.post.mock.calls[0];
-    expect(url).toBe(
-      `${environment.integrations.rest_api.url}/release-tracks/release-track--standard/contents`
-    );
-    expect(payload).toEqual(body);
-    expect(options.params.get('confirm_track_id')).toBe(
-      'release-track--standard'
-    );
-  });
-
-  it('should confirm the target ID when replacing snapshot contents', () => {
-    const body = {
-      x_mitre_contents: [
-        {
-          obj_ref: 'attack-pattern--one',
-          obj_modified: 'latest',
-        },
-      ],
-    };
-
-    service
-      .updateContentsByModified(
-        'release-track--standard',
-        '2026-07-23T13:37:28.000Z',
-        body
-      )
-      .subscribe();
-
-    const [url, payload, options] = http.post.mock.calls[0];
-    expect(url).toBe(
-      `${environment.integrations.rest_api.url}/release-tracks/release-track--standard/snapshots/2026-07-23T13%3A37%3A28.000Z/contents`
-    );
-    expect(payload).toEqual(body);
-    expect(options.params.get('confirm_track_id')).toBe(
-      'release-track--standard'
-    );
-  });
-
   it('should encode timestamps used as snapshot path parameters', () => {
     service
       .retrieveSnapshotByModified(

--- a/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
@@ -127,4 +127,63 @@ describe('ReleaseTracksConnectorService', () => {
     expect(options.params.get('limit')).toBe('25');
     expect(options.params.get('offset')).toBe('50');
   });
+
+  it('should confirm the target ID when deleting a release track', () => {
+    service.deleteReleaseTrack('release-track--standard').subscribe();
+
+    const [url, options] = http.delete.mock.calls[0];
+    expect(url).toBe(
+      `${environment.integrations.rest_api.url}/release-tracks/release-track--standard`
+    );
+    expect(options.params.get('confirm_track_id')).toBe(
+      'release-track--standard'
+    );
+  });
+
+  it('should send exact revision references when replacing latest contents', () => {
+    const body = {
+      x_mitre_contents: [
+        {
+          obj_ref: 'attack-pattern--one',
+          obj_modified: '2026-07-23T13:37:28.000Z',
+        },
+      ],
+    };
+
+    service.updateContentsByLatest('release-track--standard', body).subscribe();
+
+    const [url, payload, options] = http.post.mock.calls[0];
+    expect(url).toBe(
+      `${environment.integrations.rest_api.url}/release-tracks/release-track--standard/contents`
+    );
+    expect(payload).toEqual(body);
+    expect(options.params.get('confirm_track_id')).toBe(
+      'release-track--standard'
+    );
+  });
+
+  it('should confirm the target ID when replacing snapshot contents', () => {
+    const body = {
+      x_mitre_contents: [
+        {
+          obj_ref: 'attack-pattern--one',
+          obj_modified: 'latest',
+        },
+      ],
+    };
+
+    service
+      .updateContentsByModified(
+        'release-track--standard',
+        '2026-07-23T13:37:28.000Z',
+        body
+      )
+      .subscribe();
+
+    const [, payload, options] = http.post.mock.calls[0];
+    expect(payload).toEqual(body);
+    expect(options.params.get('confirm_track_id')).toBe(
+      'release-track--standard'
+    );
+  });
 });

--- a/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
@@ -107,11 +107,9 @@ describe('ReleaseTracksConnectorService', () => {
 
   it('should release a selected snapshot with an exact version', () => {
     service
-      .releaseSnapshot(
-        'release-track--standard',
-        '2026-07-23T13:37:28.000Z',
-        { version: '14.1' }
-      )
+      .releaseSnapshot('release-track--standard', '2026-07-23T13:37:28.000Z', {
+        version: '14.1',
+      })
       .subscribe();
 
     expect(http.post).toHaveBeenCalledWith(
@@ -155,9 +153,7 @@ describe('ReleaseTracksConnectorService', () => {
       .subscribe();
 
     const [url, options] = http.get.mock.calls[0];
-    expect(url).toBe(
-      `${environment.integrations.rest_api.url}/release-tracks`
-    );
+    expect(url).toBe(`${environment.integrations.rest_api.url}/release-tracks`);
     expect(options.params.get('type')).toBe('virtual');
     expect(options.params.get('limit')).toBe('25');
     expect(options.params.get('offset')).toBe('0');

--- a/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
@@ -109,4 +109,22 @@ describe('ReleaseTracksConnectorService', () => {
     expect((service as any).bumpByLatest).toBeUndefined();
     expect((service as any).bumpByModified).toBeUndefined();
   });
+
+  it('should preserve snapshot-history pagination and filtering', () => {
+    service
+      .listSnapshots('release-track--standard', {
+        tagged: false,
+        limit: 25,
+        offset: 50,
+      })
+      .subscribe();
+
+    const [url, options] = http.get.mock.calls[0];
+    expect(url).toBe(
+      `${environment.integrations.rest_api.url}/release-tracks/release-track--standard/snapshots`
+    );
+    expect(options.params.get('tagged')).toBe('false');
+    expect(options.params.get('limit')).toBe('25');
+    expect(options.params.get('offset')).toBe('50');
+  });
 });

--- a/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
@@ -61,4 +61,52 @@ describe('ReleaseTracksConnectorService', () => {
   it('should not expose the removed virtual snapshot preview operation', () => {
     expect((service as any).previewVirtualSnapshot).toBeUndefined();
   });
+
+  it('should preview a release with query-based version selection', () => {
+    service
+      .previewRelease('release-track--standard', {
+        format: 'summary',
+        increment: 'major',
+      })
+      .subscribe();
+
+    const [url, options] = http.get.mock.calls[0];
+    expect(url).toBe(
+      `${environment.integrations.rest_api.url}/release-tracks/release-track--standard/snapshots/latest/release/preview`
+    );
+    expect(options.params.get('format')).toBe('summary');
+    expect(options.params.get('increment')).toBe('major');
+  });
+
+  it('should release the latest snapshot with the current request body', () => {
+    service
+      .releaseLatest('release-track--standard', { increment: 'minor' })
+      .subscribe();
+
+    expect(http.post).toHaveBeenCalledWith(
+      `${environment.integrations.rest_api.url}/release-tracks/release-track--standard/snapshots/latest/release`,
+      { increment: 'minor' }
+    );
+  });
+
+  it('should release a selected snapshot with an exact version', () => {
+    service
+      .releaseSnapshot(
+        'release-track--standard',
+        '2026-07-23T13:37:28.000Z',
+        { version: '14.1' }
+      )
+      .subscribe();
+
+    expect(http.post).toHaveBeenCalledWith(
+      `${environment.integrations.rest_api.url}/release-tracks/release-track--standard/snapshots/2026-07-23T13%3A37%3A28.000Z/release`,
+      { version: '14.1' }
+    );
+  });
+
+  it('should not expose bump-oriented operations', () => {
+    expect((service as any).previewBump).toBeUndefined();
+    expect((service as any).bumpByLatest).toBeUndefined();
+    expect((service as any).bumpByModified).toBeUndefined();
+  });
 });

--- a/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.spec.ts
@@ -58,6 +58,22 @@ describe('ReleaseTracksConnectorService', () => {
     );
   });
 
+  it('should promote an exact quarantined revision', () => {
+    const body = {
+      object_ref: 'attack-pattern--one',
+      object_modified: '2026-07-23T13:37:28.000Z',
+    };
+
+    service
+      .promoteQuarantinedRevision('release-track--virtual', body)
+      .subscribe();
+
+    expect(http.post).toHaveBeenCalledWith(
+      `${environment.integrations.rest_api.url}/release-tracks/release-track--virtual/virtual/quarantine/promote`,
+      body
+    );
+  });
+
   it('should not expose the removed virtual snapshot preview operation', () => {
     expect((service as any).previewVirtualSnapshot).toBeUndefined();
   });

--- a/src/app/services/connectors/rest-api/release-tracks.service.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.ts
@@ -109,12 +109,11 @@ export class ReleaseTracksConnectorService extends ApiConnector {
   /**
    * GET /api/release-tracks
    * List release tracks.
-   * @param options Query options: type, releases, limit, offset, search
+   * @param options Query options: type, limit, offset, search
    * @returns Observable<any> paginated list
    */
   public listReleaseTracks(options?: {
     type?: string;
-    releases?: 'only';
     limit?: number;
     offset?: number;
     search?: string;

--- a/src/app/services/connectors/rest-api/release-tracks.service.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.ts
@@ -21,6 +21,7 @@ import type {
   ReleaseTrackSnapshotHistoryItem,
   ReleaseTrackSnapshotOptions,
   ReviewPayload,
+  SnapshotHistoryOptions,
   StixBundlePayload,
   StixObjectRef,
   UpdateContentsPayload,
@@ -37,6 +38,7 @@ export type {
   ReleaseTrackSnapshotHistoryItem,
   ReleaseTrackSnapshotOptions,
   ReviewPayload,
+  SnapshotHistoryOptions,
   StixBundlePayload,
   StixObjectRef,
   UpdateContentsPayload,
@@ -71,36 +73,6 @@ export class ReleaseTracksConnectorService extends ApiConnector {
       });
     }
     return params;
-  }
-
-  private normalizeSnapshotHistory(
-    result: any
-  ): ReleaseTrackSnapshotHistoryItem[] {
-    if (!result) return [];
-    if (Array.isArray(result)) return result;
-
-    const snapshots =
-      result.snapshots ||
-      result.data ||
-      result.versions ||
-      result.release_track_snapshots ||
-      result.history ||
-      [];
-
-    if (Array.isArray(snapshots) && snapshots.length) return snapshots;
-
-    const historyItems = Array.isArray(result.version_history)
-      ? result.version_history.map((entry: any) => ({
-          ...entry,
-          modified: entry.snapshot_id,
-        }))
-      : [];
-
-    if (!result.version) {
-      return [result, ...historyItems];
-    }
-
-    return historyItems.length ? historyItems : [result];
   }
 
   // -----------------------------------------------------------------------------
@@ -243,17 +215,20 @@ export class ReleaseTracksConnectorService extends ApiConnector {
    * GET /api/release-tracks/:id/snapshots
    * List snapshot history summaries.
    * @param id Release track id
-   * @returns Observable<ReleaseTrackSnapshotHistoryItem[]>
+   * @returns Observable paginated snapshot summaries
    */
   public listSnapshots(
-    id: string
-  ): Observable<ReleaseTrackSnapshotHistoryItem[]> {
+    id: string,
+    options?: SnapshotHistoryOptions
+  ): Observable<Paginated<ReleaseTrackSnapshotHistoryItem>> {
+    const params = this.buildHttpParams(options);
     const url = `${this.apiUrl}/release-tracks/${id}/snapshots`;
-    return this.http.get(url).pipe(
+    return this.http.get<Paginated<ReleaseTrackSnapshotHistoryItem>>(url, {
+      params,
+    }).pipe(
       tap(result => logger.log(`retrieved snapshots for track ${id}`, result)),
-      map(result => this.normalizeSnapshotHistory(result)),
       catchError(
-        this.handleError_continue<ReleaseTrackSnapshotHistoryItem[]>([])
+        this.handleError_raise<Paginated<ReleaseTrackSnapshotHistoryItem>>()
       ),
       share()
     );

--- a/src/app/services/connectors/rest-api/release-tracks.service.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.ts
@@ -7,15 +7,16 @@ import { environment } from '../../../../environments/environment';
 import { logger } from '../../../utils/logger';
 import { ApiConnector } from '../api-connector';
 import {
-  ExportFormat,
+  ReleasePreviewFormat,
   ReleaseTrackSnapshot,
 } from 'src/app/classes/release-tracks';
 import type {
-  BumpPayload,
   ClonePayload,
   Composition,
   CreateReleaseTrackPayload,
   ExportFormatType,
+  ReleasePayload,
+  ReleasePreviewOptions,
   ReleaseTrackConfig,
   ReleaseTrackSnapshotHistoryItem,
   ReleaseTrackSnapshotOptions,
@@ -28,10 +29,11 @@ import type {
 import { Paginated } from './rest-api-connector.service';
 
 export type {
-  BumpPayload,
   ClonePayload,
   Composition,
   CreateReleaseTrackPayload,
+  ReleasePayload,
+  ReleasePreviewOptions,
   ReleaseTrackSnapshotHistoryItem,
   ReleaseTrackSnapshotOptions,
   ReviewPayload,
@@ -366,36 +368,41 @@ export class ReleaseTracksConnectorService extends ApiConnector {
    * @param modified Optional snapshot modified timestamp
    * @returns Observable<any> preview payload
    */
-  public previewBump(
+  public previewRelease(
     id: string,
-    format: ExportFormatType = ExportFormat.Workbench,
+    options: ReleasePreviewOptions = { format: ReleasePreviewFormat.Summary },
     modified?: string
   ): Observable<any> {
-    const params = this.buildHttpParams({ format });
+    const params = this.buildHttpParams({
+      format: ReleasePreviewFormat.Summary,
+      ...options,
+    });
     const snapshotPath = modified
-      ? `snapshots/${modified}`
+      ? `snapshots/${encodeURIComponent(modified)}`
       : 'snapshots/latest';
     const url = `${this.apiUrl}/release-tracks/${id}/${snapshotPath}/release/preview`;
     return this.http.get(url, { params }).pipe(
       tap(result =>
-        logger.log(`generated bump preview for track ${id}`, result)
+        logger.log(`generated release preview for track ${id}`, result)
       ),
-      catchError(this.handleError_continue<any>(null)),
+      catchError(this.handleError_raise()),
       share()
     );
   }
 
   /**
    * POST /api/release-tracks/:id/snapshots/latest/release
-   * Bump/tag the latest snapshot.
+   * Release/tag the latest snapshot.
    * @param id Release track id
-   * @param body Bump options (type, version, dry_run)
+   * @param body Release version selector
    * @returns Observable<any>
    */
-  public bumpByLatest(id: string, body: BumpPayload): Observable<any> {
+  public releaseLatest(id: string, body: ReleasePayload): Observable<any> {
     const url = `${this.apiUrl}/release-tracks/${id}/snapshots/latest/release`;
     return this.http.post(url, body).pipe(
-      tap(result => logger.log(`bumped version for track ${id}`, result)),
+      tap(result =>
+        logger.log(`released latest snapshot for track ${id}`, result)
+      ),
       catchError(this.handleError_raise()),
       share()
     );
@@ -522,19 +529,17 @@ export class ReleaseTracksConnectorService extends ApiConnector {
    * Tag/release a specific snapshot.
    * @param id Release track id
    * @param modified Snapshot modified timestamp
-   * @param body Bump options
+   * @param body Release version selector
    * @returns Observable<any>
    */
-  public bumpByModified(
+  public releaseSnapshot(
     id: string,
     modified: string,
-    body: BumpPayload
+    body: ReleasePayload
   ): Observable<any> {
-    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${modified}/release`;
+    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${encodeURIComponent(modified)}/release`;
     return this.http.post(url, body).pipe(
-      tap(result =>
-        logger.log(`bumped version for snapshot ${modified}`, result)
-      ),
+      tap(result => logger.log(`released snapshot ${modified}`, result)),
       catchError(this.handleError_raise()),
       share()
     );

--- a/src/app/services/connectors/rest-api/release-tracks.service.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.ts
@@ -25,7 +25,6 @@ import type {
   SnapshotHistoryOptions,
   StixBundlePayload,
   StixObjectRef,
-  UpdateContentsPayload,
   UpdateMetadataPayload,
 } from 'src/app/classes/release-tracks';
 import { Paginated } from './rest-api-connector.service';
@@ -43,7 +42,6 @@ export type {
   SnapshotHistoryOptions,
   StixBundlePayload,
   StixObjectRef,
-  UpdateContentsPayload,
   UpdateMetadataPayload,
 } from 'src/app/classes/release-tracks';
 
@@ -318,26 +316,6 @@ export class ReleaseTracksConnectorService extends ApiConnector {
   }
 
   /**
-   * POST /api/release-tracks/:id/contents
-   * Update member contents for latest snapshot.
-   * @param id Release track id
-   * @param body Contents payload
-   * @returns Observable<any>
-   */
-  public updateContentsByLatest(
-    id: string,
-    body: UpdateContentsPayload
-  ): Observable<any> {
-    const params = this.buildHttpParams({ confirm_track_id: id });
-    const url = `${this.apiUrl}/release-tracks/${id}/contents`;
-    return this.http.post(url, body, { params }).pipe(
-      tap(result => logger.log(`updated contents for track ${id}`, result)),
-      catchError(this.handleError_raise()),
-      share()
-    );
-  }
-
-  /**
    * GET /api/release-tracks/:id/snapshots/latest/release/preview
    * GET /api/release-tracks/:id/snapshots/:modified/release/preview
    * Preview a release for a track snapshot.
@@ -448,56 +426,6 @@ export class ReleaseTracksConnectorService extends ApiConnector {
   }
 
   /**
-   * POST /api/release-tracks/:id/snapshots/:modified/meta
-   * Update metadata for a specific snapshot.
-   * @param id Release track id
-   * @param modified Snapshot modified timestamp
-   * @param body Metadata payload
-   * @param userAccountId Optional user
-   * @returns Observable<any>
-   */
-  public updateMetadataByModified(
-    id: string,
-    modified: string,
-    body: UpdateMetadataPayload,
-    userAccountId?: string
-  ): Observable<any> {
-    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${encodeURIComponent(modified)}/meta`;
-    const payload = userAccountId ? { ...body, userAccountId } : body;
-    return this.http.post(url, payload).pipe(
-      tap(result =>
-        logger.log(`updated metadata for snapshot ${modified}`, result)
-      ),
-      catchError(this.handleError_raise()),
-      share()
-    );
-  }
-
-  /**
-   * POST /api/release-tracks/:id/snapshots/:modified/contents
-   * Update contents for a specific snapshot.
-   * @param id Release track id
-   * @param modified Snapshot modified timestamp
-   * @param body Contents payload
-   * @returns Observable<any>
-   */
-  public updateContentsByModified(
-    id: string,
-    modified: string,
-    body: UpdateContentsPayload
-  ): Observable<any> {
-    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${encodeURIComponent(modified)}/contents`;
-    const params = this.buildHttpParams({ confirm_track_id: id });
-    return this.http.post(url, body, { params }).pipe(
-      tap(result =>
-        logger.log(`updated contents for snapshot ${modified}`, result)
-      ),
-      catchError(this.handleError_raise()),
-      share()
-    );
-  }
-
-  /**
    * POST /api/release-tracks/:id/snapshots/:modified/release
    * Tag/release a specific snapshot.
    * @param id Release track id
@@ -541,7 +469,7 @@ export class ReleaseTracksConnectorService extends ApiConnector {
 
   /**
    * DELETE /api/release-tracks/:id/snapshots/:modified
-   * Delete a specific snapshot.
+   * Delete the latest untagged draft snapshot.
    * @param id Release track id
    * @param modified Snapshot modified timestamp
    * @returns Observable<unknown>

--- a/src/app/services/connectors/rest-api/release-tracks.service.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.ts
@@ -224,15 +224,19 @@ export class ReleaseTracksConnectorService extends ApiConnector {
   ): Observable<Paginated<ReleaseTrackSnapshotHistoryItem>> {
     const params = this.buildHttpParams(options);
     const url = `${this.apiUrl}/release-tracks/${id}/snapshots`;
-    return this.http.get<Paginated<ReleaseTrackSnapshotHistoryItem>>(url, {
-      params,
-    }).pipe(
-      tap(result => logger.log(`retrieved snapshots for track ${id}`, result)),
-      catchError(
-        this.handleError_raise<Paginated<ReleaseTrackSnapshotHistoryItem>>()
-      ),
-      share()
-    );
+    return this.http
+      .get<Paginated<ReleaseTrackSnapshotHistoryItem>>(url, {
+        params,
+      })
+      .pipe(
+        tap(result =>
+          logger.log(`retrieved snapshots for track ${id}`, result)
+        ),
+        catchError(
+          this.handleError_raise<Paginated<ReleaseTrackSnapshotHistoryItem>>()
+        ),
+        share()
+      );
   }
 
   /**
@@ -404,9 +408,7 @@ export class ReleaseTracksConnectorService extends ApiConnector {
    * @param id Release track id
    * @returns Observable<unknown>
    */
-  public deleteReleaseTrack(
-    id: string
-  ): Observable<unknown> {
+  public deleteReleaseTrack(id: string): Observable<unknown> {
     const params = this.buildHttpParams({ confirm_track_id: id });
     const url = `${this.apiUrl}/release-tracks/${id}`;
     return this.http.delete(url, { params }).pipe(

--- a/src/app/services/connectors/rest-api/release-tracks.service.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.ts
@@ -15,6 +15,7 @@ import type {
   Composition,
   CreateReleaseTrackPayload,
   ExportFormatType,
+  PromoteQuarantinePayload,
   ReleasePayload,
   ReleasePreviewOptions,
   ReleaseTrackConfig,
@@ -33,6 +34,7 @@ export type {
   ClonePayload,
   Composition,
   CreateReleaseTrackPayload,
+  PromoteQuarantinePayload,
   ReleasePayload,
   ReleasePreviewOptions,
   ReleaseTrackSnapshotHistoryItem,
@@ -593,6 +595,27 @@ export class ReleaseTracksConnectorService extends ApiConnector {
     return this.http.put(url, payload).pipe(
       tap(result =>
         logger.log(`updated virtual composition for track ${id}`, result)
+      ),
+      catchError(this.handleError_raise()),
+      share()
+    );
+  }
+
+  /**
+   * POST /api/release-tracks/:id/virtual/quarantine/promote
+   * Resolve one quarantined object to an exact revision in a new virtual draft.
+   * @param id Virtual release track id
+   * @param body Exact quarantined object revision to promote
+   * @returns Observable<any>
+   */
+  public promoteQuarantinedRevision(
+    id: string,
+    body: PromoteQuarantinePayload
+  ): Observable<any> {
+    const url = `${this.apiUrl}/release-tracks/${id}/virtual/quarantine/promote`;
+    return this.http.post(url, body).pipe(
+      tap(result =>
+        logger.log(`promoted quarantined revision for track ${id}`, result)
       ),
       catchError(this.handleError_raise()),
       share()

--- a/src/app/services/connectors/rest-api/release-tracks.service.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.ts
@@ -317,17 +317,15 @@ export class ReleaseTracksConnectorService extends ApiConnector {
    * Update member contents for latest snapshot.
    * @param id Release track id
    * @param body Contents payload
-   * @param userAccountId Optional user
    * @returns Observable<any>
    */
   public updateContentsByLatest(
     id: string,
-    body: UpdateContentsPayload,
-    userAccountId?: string
+    body: UpdateContentsPayload
   ): Observable<any> {
+    const params = this.buildHttpParams({ confirm_track_id: id });
     const url = `${this.apiUrl}/release-tracks/${id}/contents`;
-    const payload = userAccountId ? { ...body, userAccountId } : body;
-    return this.http.post(url, payload).pipe(
+    return this.http.post(url, body, { params }).pipe(
       tap(result => logger.log(`updated contents for track ${id}`, result)),
       catchError(this.handleError_raise()),
       share()
@@ -406,10 +404,9 @@ export class ReleaseTracksConnectorService extends ApiConnector {
    * @returns Observable<unknown>
    */
   public deleteReleaseTrack(
-    id: string,
-    options?: { versions?: 'latest' }
+    id: string
   ): Observable<unknown> {
-    const params = this.buildHttpParams(options);
+    const params = this.buildHttpParams({ confirm_track_id: id });
     const url = `${this.apiUrl}/release-tracks/${id}`;
     return this.http.delete(url, { params }).pipe(
       tap(() => logger.log(`deleted track ${id}`)),
@@ -479,18 +476,16 @@ export class ReleaseTracksConnectorService extends ApiConnector {
    * @param id Release track id
    * @param modified Snapshot modified timestamp
    * @param body Contents payload
-   * @param userAccountId Optional user
    * @returns Observable<any>
    */
   public updateContentsByModified(
     id: string,
     modified: string,
-    body: UpdateContentsPayload,
-    userAccountId?: string
+    body: UpdateContentsPayload
   ): Observable<any> {
     const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${modified}/contents`;
-    const payload = userAccountId ? { ...body, userAccountId } : body;
-    return this.http.post(url, payload).pipe(
+    const params = this.buildHttpParams({ confirm_track_id: id });
+    return this.http.post(url, body, { params }).pipe(
       tap(result =>
         logger.log(`updated contents for snapshot ${modified}`, result)
       ),

--- a/src/app/services/connectors/rest-api/release-tracks.service.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.ts
@@ -581,7 +581,7 @@ export class ReleaseTracksConnectorService extends ApiConnector {
   }
 
   /**
-   * POST /api/release-tracks/:id/snapshots/create
+   * POST /api/release-tracks/:id/virtual/snapshots/create
    * Resolve component tracks and create a new draft snapshot for a virtual track.
    * @param id Release track id
    * @param body Optional snapshot creation options
@@ -591,7 +591,7 @@ export class ReleaseTracksConnectorService extends ApiConnector {
     id: string,
     body?: { description?: string }
   ): Observable<any> {
-    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/create`;
+    const url = `${this.apiUrl}/release-tracks/${id}/virtual/snapshots/create`;
     return this.http.post(url, body || {}).pipe(
       tap(result =>
         logger.log(`created virtual snapshot for track ${id}`, result)
@@ -602,24 +602,7 @@ export class ReleaseTracksConnectorService extends ApiConnector {
   }
 
   /**
-   * GET /api/release-tracks/:id/snapshots/preview
-   * Preview the resolved contents of a virtual snapshot without creating it.
-   * @param id Release track id
-   * @returns Observable<any>
-   */
-  public previewVirtualSnapshot(id: string): Observable<any> {
-    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/preview`;
-    return this.http.get(url).pipe(
-      tap(result =>
-        logger.log(`previewed virtual snapshot for track ${id}`, result)
-      ),
-      catchError(this.handleError_continue<any>(null)),
-      share()
-    );
-  }
-
-  /**
-   * PUT /api/release-tracks/:id/composition
+   * PUT /api/release-tracks/:id/virtual/composition
    * Update the composition rules for a virtual release track.
    * @param id Release track id
    * @param body Composition payload
@@ -630,7 +613,7 @@ export class ReleaseTracksConnectorService extends ApiConnector {
     body: Composition,
     userAccountId?: string
   ): Observable<any> {
-    const url = `${this.apiUrl}/release-tracks/${id}/composition`;
+    const url = `${this.apiUrl}/release-tracks/${id}/virtual/composition`;
     const payload = userAccountId ? { ...body, userAccountId } : body;
     return this.http.put(url, payload).pipe(
       tap(result =>

--- a/src/app/services/connectors/rest-api/release-tracks.service.ts
+++ b/src/app/services/connectors/rest-api/release-tracks.service.ts
@@ -277,7 +277,7 @@ export class ReleaseTracksConnectorService extends ApiConnector {
     options?: Omit<ReleaseTrackSnapshotOptions, 'format'>
   ): Observable<any> {
     const params = this.buildHttpParams({ ...options, format });
-    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${modified}`;
+    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${encodeURIComponent(modified)}`;
     return this.http.get(url, { params }).pipe(
       tap(result =>
         logger.log(
@@ -433,7 +433,7 @@ export class ReleaseTracksConnectorService extends ApiConnector {
     options?: ReleaseTrackSnapshotOptions
   ): Observable<ReleaseTrackSnapshot | null> {
     const params = this.buildHttpParams(options);
-    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${modified}`;
+    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${encodeURIComponent(modified)}`;
     return this.http.get(url, { params }).pipe(
       tap(result =>
         logger.log(`retrieved snapshot ${modified} for track ${id}`, result)
@@ -459,7 +459,7 @@ export class ReleaseTracksConnectorService extends ApiConnector {
     body: UpdateMetadataPayload,
     userAccountId?: string
   ): Observable<any> {
-    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${modified}/meta`;
+    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${encodeURIComponent(modified)}/meta`;
     const payload = userAccountId ? { ...body, userAccountId } : body;
     return this.http.post(url, payload).pipe(
       tap(result =>
@@ -483,7 +483,7 @@ export class ReleaseTracksConnectorService extends ApiConnector {
     modified: string,
     body: UpdateContentsPayload
   ): Observable<any> {
-    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${modified}/contents`;
+    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${encodeURIComponent(modified)}/contents`;
     const params = this.buildHttpParams({ confirm_track_id: id });
     return this.http.post(url, body, { params }).pipe(
       tap(result =>
@@ -528,7 +528,7 @@ export class ReleaseTracksConnectorService extends ApiConnector {
     modified: string,
     body?: ClonePayload
   ): Observable<any> {
-    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${modified}/clone`;
+    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${encodeURIComponent(modified)}/clone`;
     return this.http.post(url, body || {}).pipe(
       tap(result => logger.log(`cloned from snapshot ${modified}`, result)),
       catchError(this.handleError_raise()),
@@ -547,7 +547,7 @@ export class ReleaseTracksConnectorService extends ApiConnector {
     id: string,
     modified: string
   ): Observable<unknown> {
-    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${modified}`;
+    const url = `${this.apiUrl}/release-tracks/${id}/snapshots/${encodeURIComponent(modified)}`;
     return this.http.delete(url).pipe(
       tap(() => logger.log(`deleted snapshot ${modified} from track ${id}`)),
       catchError(this.handleError_raise()),

--- a/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.html
+++ b/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.html
@@ -684,25 +684,19 @@
                 </div>
                 <div class="snapshot-history-stat-label">Members</div>
               </div>
-              <div
-                *ngIf="!item.isVirtual"
-                class="snapshot-history-stat">
+              <div *ngIf="!item.isVirtual" class="snapshot-history-stat">
                 <div class="snapshot-history-stat-value modified-color">
                   {{ item.stagedCount }}
                 </div>
                 <div class="snapshot-history-stat-label">Staged</div>
               </div>
-              <div
-                *ngIf="!item.isVirtual"
-                class="snapshot-history-stat">
+              <div *ngIf="!item.isVirtual" class="snapshot-history-stat">
                 <div class="snapshot-history-stat-value">
                   {{ item.candidatesCount }}
                 </div>
                 <div class="snapshot-history-stat-label">Candidates</div>
               </div>
-              <div
-                *ngIf="item.isVirtual"
-                class="snapshot-history-stat">
+              <div *ngIf="item.isVirtual" class="snapshot-history-stat">
                 <div class="snapshot-history-stat-value">
                   {{ item.quarantineCount }}
                 </div>

--- a/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.html
+++ b/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.html
@@ -679,22 +679,34 @@
 
             <div class="snapshot-history-stats">
               <div class="snapshot-history-stat">
-                <div class="snapshot-history-stat-value promote-color">
-                  +{{ item.addedCount }}
-                </div>
-                <div class="snapshot-history-stat-label">Added</div>
-              </div>
-              <div class="snapshot-history-stat">
-                <div class="snapshot-history-stat-value modified-color">
-                  {{ item.modifiedCount }}
-                </div>
-                <div class="snapshot-history-stat-label">Modified</div>
-              </div>
-              <div class="snapshot-history-stat">
                 <div class="snapshot-history-stat-value">
-                  {{ item.totalObjects }}
+                  {{ item.membersCount }}
                 </div>
-                <div class="snapshot-history-stat-label">Total Objects</div>
+                <div class="snapshot-history-stat-label">Members</div>
+              </div>
+              <div
+                *ngIf="!item.isVirtual"
+                class="snapshot-history-stat">
+                <div class="snapshot-history-stat-value modified-color">
+                  {{ item.stagedCount }}
+                </div>
+                <div class="snapshot-history-stat-label">Staged</div>
+              </div>
+              <div
+                *ngIf="!item.isVirtual"
+                class="snapshot-history-stat">
+                <div class="snapshot-history-stat-value">
+                  {{ item.candidatesCount }}
+                </div>
+                <div class="snapshot-history-stat-label">Candidates</div>
+              </div>
+              <div
+                *ngIf="item.isVirtual"
+                class="snapshot-history-stat">
+                <div class="snapshot-history-stat-value">
+                  {{ item.quarantineCount }}
+                </div>
+                <div class="snapshot-history-stat-label">Quarantine</div>
               </div>
             </div>
           </div>

--- a/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.spec.ts
+++ b/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.spec.ts
@@ -47,9 +47,9 @@ describe('ReleaseTrackPageComponent', () => {
       exportSnapshotByModified: vi.fn(() => createAsyncObservable({})),
       retrieveSnapshotByModified: vi.fn(() => createAsyncObservable(null)),
       createVirtualSnapshot: vi.fn(() => createAsyncObservable({})),
-      previewBump: vi.fn(() => createAsyncObservable({})),
-      bumpByLatest: vi.fn(() => createAsyncObservable({})),
-      bumpByModified: vi.fn(() => createAsyncObservable({})),
+      previewRelease: vi.fn(() => createAsyncObservable({})),
+      releaseLatest: vi.fn(() => createAsyncObservable({})),
+      releaseSnapshot: vi.fn(() => createAsyncObservable({})),
       getConfig: vi.fn(() => createAsyncObservable(null)),
       updateConfig: vi.fn(() => createAsyncObservable({})),
       updateComposition: vi.fn(() => createAsyncObservable({})),
@@ -574,26 +574,41 @@ describe('ReleaseTrackPageComponent', () => {
     const historySpy = vi
       .spyOn(component, 'getSnapshotHistory')
       .mockImplementation(() => undefined);
-    mockReleaseTrackApiConnector.previewBump.mockReturnValue(
+    mockReleaseTrackApiConnector.previewRelease.mockReturnValue(
       of({
-        next_version_minor: '1.2',
-        next_version_major: '2.0',
-        staged_count: 3,
-        candidates_count: 1,
+        type: ReleaseTrackType.Standard,
+        version: '1.2',
+        before: {
+          members_count: 10,
+          staged_count: 3,
+          candidates_count: 1,
+        },
+        after: {
+          members_count: 13,
+          staged_count: 0,
+          candidates_count: 1,
+        },
+        changes: {
+          promoted_count: 3,
+        },
         conflicts: [],
       })
     );
-    mockReleaseTrackApiConnector.bumpByLatest.mockReturnValue(of({}));
-    mockDialog.open.mockReturnValue({
-      afterClosed: () => of('minor'),
-    });
+    mockReleaseTrackApiConnector.releaseLatest.mockReturnValue(of({}));
+    mockDialog.open
+      .mockReturnValueOnce({
+        afterClosed: () => of('minor'),
+      })
+      .mockReturnValueOnce({
+        afterClosed: () => of('release'),
+      });
     component.id = 'release-track--123';
 
     component.onPreviewRelease();
 
-    expect(mockReleaseTrackApiConnector.previewBump).toHaveBeenCalledWith(
+    expect(mockReleaseTrackApiConnector.previewRelease).toHaveBeenCalledWith(
       'release-track--123',
-      'workbench'
+      { format: 'summary', increment: 'minor' }
     );
     expect(mockDialog.open).toHaveBeenCalledWith(
       MultipleChoiceDialogComponent,
@@ -603,9 +618,9 @@ describe('ReleaseTrackPageComponent', () => {
         }),
       })
     );
-    expect(mockReleaseTrackApiConnector.bumpByLatest).toHaveBeenCalledWith(
+    expect(mockReleaseTrackApiConnector.releaseLatest).toHaveBeenCalledWith(
       'release-track--123',
-      { type: 'minor' }
+      { increment: 'minor' }
     );
     expect(refreshSpy).toHaveBeenCalled();
     expect(historySpy).toHaveBeenCalled();
@@ -619,17 +634,34 @@ describe('ReleaseTrackPageComponent', () => {
     const historySpy = vi
       .spyOn(component, 'getSnapshotHistory')
       .mockImplementation(() => undefined);
-    mockReleaseTrackApiConnector.previewBump.mockReturnValue(
+    mockReleaseTrackApiConnector.previewRelease.mockReturnValue(
       of({
-        next_version_minor: '1.2',
-        next_version_major: '2.0',
+        type: ReleaseTrackType.Standard,
+        version: '2.0',
+        before: {
+          members_count: 10,
+          staged_count: 3,
+          candidates_count: 1,
+        },
+        after: {
+          members_count: 13,
+          staged_count: 0,
+          candidates_count: 1,
+        },
+        changes: {
+          promoted_count: 3,
+        },
         conflicts: [],
       })
     );
-    mockReleaseTrackApiConnector.bumpByModified.mockReturnValue(of({}));
-    mockDialog.open.mockReturnValue({
-      afterClosed: () => of('major'),
-    });
+    mockReleaseTrackApiConnector.releaseSnapshot.mockReturnValue(of({}));
+    mockDialog.open
+      .mockReturnValueOnce({
+        afterClosed: () => of('major'),
+      })
+      .mockReturnValueOnce({
+        afterClosed: () => of('release'),
+      });
     component.id = 'release-track--123';
 
     component.onTagSnapshot({
@@ -637,24 +669,26 @@ describe('ReleaseTrackPageComponent', () => {
       isTagged: false,
     } as any);
 
-    expect(mockReleaseTrackApiConnector.previewBump).toHaveBeenCalledWith(
+    expect(mockReleaseTrackApiConnector.previewRelease).toHaveBeenCalledWith(
       'release-track--123',
-      'workbench',
+      { format: 'summary', increment: 'major' },
       '2026-07-23T13:37:28.000Z'
     );
-    expect(mockReleaseTrackApiConnector.bumpByModified).toHaveBeenCalledWith(
+    expect(mockReleaseTrackApiConnector.releaseSnapshot).toHaveBeenCalledWith(
       'release-track--123',
       '2026-07-23T13:37:28.000Z',
-      { type: 'major' }
+      { increment: 'major' }
     );
-    expect(mockReleaseTrackApiConnector.bumpByLatest).not.toHaveBeenCalled();
+    expect(mockReleaseTrackApiConnector.releaseLatest).not.toHaveBeenCalled();
     expect(refreshSpy).toHaveBeenCalled();
     expect(historySpy).toHaveBeenCalled();
   });
 
   it('should not tag a release when preview returns conflicts', () => {
-    mockReleaseTrackApiConnector.previewBump.mockReturnValue(
+    mockReleaseTrackApiConnector.previewRelease.mockReturnValue(
       of({
+        type: ReleaseTrackType.Standard,
+        version: '1.2',
         conflicts: [
           {
             object_ref: 'attack-pattern--123',
@@ -664,9 +698,11 @@ describe('ReleaseTrackPageComponent', () => {
         ],
       })
     );
-    mockDialog.open.mockReturnValue({
-      afterClosed: () => of('close'),
-    });
+    mockDialog.open
+      .mockReturnValueOnce({
+        afterClosed: () => of('minor'),
+      })
+      .mockReturnValueOnce({});
     component.id = 'release-track--123';
 
     component.onPreviewRelease();
@@ -679,7 +715,7 @@ describe('ReleaseTrackPageComponent', () => {
         }),
       })
     );
-    expect(mockReleaseTrackApiConnector.bumpByLatest).not.toHaveBeenCalled();
+    expect(mockReleaseTrackApiConnector.releaseLatest).not.toHaveBeenCalled();
   });
 
   it('should load release track config into the config form', () => {

--- a/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.spec.ts
+++ b/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.spec.ts
@@ -42,7 +42,12 @@ describe('ReleaseTrackPageComponent', () => {
     mockReleaseTrackApiConnector = createMockReleaseTrackApiConnector({
       getLatestSnapshot: vi.fn(() => createAsyncObservable(null)),
       listReleaseTracks: vi.fn(() => createAsyncObservable({ data: [] })),
-      listSnapshots: vi.fn(() => createAsyncObservable([])),
+      listSnapshots: vi.fn(() =>
+        createAsyncObservable({
+          data: [],
+          pagination: { total: 0, limit: 50, offset: 0 },
+        })
+      ),
       exportLatestSnapshot: vi.fn(() => createAsyncObservable({})),
       exportSnapshotByModified: vi.fn(() => createAsyncObservable({})),
       retrieveSnapshotByModified: vi.fn(() => createAsyncObservable(null)),
@@ -422,33 +427,32 @@ describe('ReleaseTrackPageComponent', () => {
     ]);
   });
 
-  it('should load snapshot history and compute timeline counts', () => {
+  it('should load the type-oriented counts from snapshot summaries', () => {
     mockReleaseTrackApiConnector.listSnapshots.mockReturnValue(
-      of([
-        {
-          modified: '2024-05-21T07:00:00.000Z',
-          members: [
-            {
-              object_ref: 'attack-pattern--one',
-              object_modified: '2024-05-20T00:00:00.000Z',
-            },
-            {
-              object_ref: 'attack-pattern--two',
-              object_modified: '2024-05-20T00:00:00.000Z',
-            },
-          ],
-        },
-        {
-          version: '1.3',
-          modified: '2024-04-15T06:00:00.000Z',
-          members: [
-            {
-              object_ref: 'attack-pattern--one',
-              object_modified: '2024-04-01T00:00:00.000Z',
-            },
-          ],
-        },
-      ])
+      of({
+        data: [
+          {
+            id: 'release-track--123',
+            type: 'standard',
+            modified: '2024-05-21T07:00:00.000Z',
+            version: null,
+            name: 'Enterprise',
+            members_count: 2,
+            staged_count: 3,
+            candidates_count: 4,
+          },
+          {
+            id: 'release-track--456',
+            type: 'virtual',
+            version: '1.3',
+            modified: '2024-04-15T06:00:00.000Z',
+            name: 'Combined',
+            members_count: 5,
+            quarantine_count: 1,
+          },
+        ],
+        pagination: { total: 2, limit: 50, offset: 0 },
+      })
     );
     component.id = 'release-track--123';
 
@@ -460,17 +464,18 @@ describe('ReleaseTrackPageComponent', () => {
     expect(component.snapshotHistory[0]).toEqual(
       expect.objectContaining({
         title: 'Draft Snapshot',
-        addedCount: 1,
-        modifiedCount: 1,
-        totalObjects: 2,
+        isVirtual: false,
+        membersCount: 2,
+        stagedCount: 3,
+        candidatesCount: 4,
       })
     );
     expect(component.snapshotHistory[1]).toEqual(
       expect.objectContaining({
         title: 'v1.3',
-        addedCount: 0,
-        modifiedCount: 0,
-        totalObjects: 1,
+        isVirtual: true,
+        membersCount: 5,
+        quarantineCount: 1,
       })
     );
   });

--- a/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.spec.ts
+++ b/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.spec.ts
@@ -46,7 +46,6 @@ describe('ReleaseTrackPageComponent', () => {
       exportLatestSnapshot: vi.fn(() => createAsyncObservable({})),
       exportSnapshotByModified: vi.fn(() => createAsyncObservable({})),
       retrieveSnapshotByModified: vi.fn(() => createAsyncObservable(null)),
-      previewVirtualSnapshot: vi.fn(() => createAsyncObservable({})),
       createVirtualSnapshot: vi.fn(() => createAsyncObservable({})),
       previewBump: vi.fn(() => createAsyncObservable({})),
       bumpByLatest: vi.fn(() => createAsyncObservable({})),
@@ -483,21 +482,6 @@ describe('ReleaseTrackPageComponent', () => {
     const historySpy = vi
       .spyOn(component, 'getSnapshotHistory')
       .mockImplementation(() => undefined);
-    mockReleaseTrackApiConnector.previewVirtualSnapshot.mockReturnValue(
-      of({
-        preview: {
-          would_resolve_to: {
-            total_objects: 20,
-            component_snapshots: [
-              {
-                track_name: 'Component Track',
-                resolved_version: '1.0',
-              },
-            ],
-          },
-        },
-      })
-    );
     mockDialog.open.mockReturnValue({
       afterClosed: () => of('create'),
     });
@@ -507,15 +491,12 @@ describe('ReleaseTrackPageComponent', () => {
 
     component.onDraft();
 
-    expect(
-      mockReleaseTrackApiConnector.previewVirtualSnapshot
-    ).toHaveBeenCalledWith('release-track--123');
     expect(mockDialog.open).toHaveBeenCalledWith(
       MultipleChoiceDialogComponent,
       expect.objectContaining({
         data: expect.objectContaining({
           title: 'Create draft snapshot?',
-          description: expect.stringContaining('20 objects'),
+          description: expect.stringContaining('persistent virtual draft'),
         }),
       })
     );
@@ -535,8 +516,9 @@ describe('ReleaseTrackPageComponent', () => {
 
     component.onDraft();
 
+    expect(mockDialog.open).not.toHaveBeenCalled();
     expect(
-      mockReleaseTrackApiConnector.previewVirtualSnapshot
+      mockReleaseTrackApiConnector.createVirtualSnapshot
     ).not.toHaveBeenCalled();
   });
 
@@ -546,8 +528,9 @@ describe('ReleaseTrackPageComponent', () => {
 
     component.onDraft();
 
+    expect(mockDialog.open).not.toHaveBeenCalled();
     expect(
-      mockReleaseTrackApiConnector.previewVirtualSnapshot
+      mockReleaseTrackApiConnector.createVirtualSnapshot
     ).not.toHaveBeenCalled();
   });
 

--- a/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.ts
+++ b/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.ts
@@ -17,6 +17,8 @@ import {
   MemberSyncPolicyType,
   MemberSyncStrategy,
   MemberSyncStrategyType,
+  ReleasePayload,
+  ReleasePreviewFormat,
   ReleaseTrackConfig,
   ReleaseTrackSnapshot,
   ReleaseTrackSnapshotHistoryItem,
@@ -1346,24 +1348,60 @@ export class ReleaseTrackPageComponent implements OnInit {
   }
 
   public onPreviewRelease(): void {
-    this.previewRelease();
+    this.chooseReleaseIncrement();
   }
 
   public onTagSnapshot(item: SnapshotHistoryViewModel): void {
-    this.previewRelease(item);
+    this.chooseReleaseIncrement(item);
   }
 
-  private previewRelease(item?: SnapshotHistoryViewModel): void {
+  private chooseReleaseIncrement(item?: SnapshotHistoryViewModel): void {
     if (!this.id || this.isReleasing) return;
 
+    const selectionRef = this.dialog.open(MultipleChoiceDialogComponent, {
+      width: '34em',
+      autoFocus: false,
+      data: {
+        title: 'Choose a release version',
+        description:
+          'Use the next minor or major version for the release preview.',
+        choices: [
+          {
+            label: 'Next minor version',
+            value: 'minor',
+          },
+          {
+            label: 'Next major version',
+            value: 'major',
+          },
+        ],
+      },
+    });
+
+    selectionRef
+      .afterClosed()
+      .pipe(take(1))
+      .subscribe((increment: 'major' | 'minor' | undefined) => {
+        if (increment !== 'major' && increment !== 'minor') return;
+        this.previewRelease({ increment }, item);
+      });
+  }
+
+  private previewRelease(
+    selection: ReleasePayload,
+    item?: SnapshotHistoryViewModel
+  ): void {
     this.isReleasing = true;
     const preview = item?.modified
-      ? this.connector.previewBump(
+      ? this.connector.previewRelease(
           this.id,
-          ExportFormat.Workbench,
+          { format: ReleasePreviewFormat.Summary, ...selection },
           item.modified
         )
-      : this.connector.previewBump(this.id, ExportFormat.Workbench);
+      : this.connector.previewRelease(this.id, {
+          format: ReleasePreviewFormat.Summary,
+          ...selection,
+        });
 
     preview
       .pipe(
@@ -1373,9 +1411,10 @@ export class ReleaseTrackPageComponent implements OnInit {
         })
       )
       .subscribe({
-        next: preview => this.openReleasePreviewDialog(preview, item),
+        next: preview =>
+          this.openReleasePreviewDialog(preview, selection, item),
         error: err => {
-          console.error('Failed to preview release track bump', err);
+          console.error('Failed to preview release track release', err);
         },
       });
   }
@@ -1732,6 +1771,7 @@ export class ReleaseTrackPageComponent implements OnInit {
 
   private openReleasePreviewDialog(
     preview: any,
+    selection: ReleasePayload,
     item?: SnapshotHistoryViewModel
   ): void {
     const conflicts = this.getReleaseConflicts(preview);
@@ -1758,23 +1798,13 @@ export class ReleaseTrackPageComponent implements OnInit {
       return;
     }
 
-    const minorVersion = preview?.next_version_minor || preview?.next_version;
-    const majorVersion = preview?.next_version_major;
     const choices = [
       {
-        label: `Minor Release${minorVersion ? ` (${minorVersion})` : ''}`,
-        value: 'minor',
+        label: `Release${preview?.version ? ` (${preview.version})` : ''}`,
+        value: 'release',
         description: this.getReleasePreviewDescription(preview),
       },
     ];
-
-    if (majorVersion) {
-      choices.push({
-        label: `Major Release (${majorVersion})`,
-        value: 'major',
-        description: this.getReleasePreviewDescription(preview),
-      });
-    }
 
     const releaseRef = this.dialog.open(MultipleChoiceDialogComponent, {
       width: '34em',
@@ -1782,7 +1812,7 @@ export class ReleaseTrackPageComponent implements OnInit {
       data: {
         title: 'Preview & release',
         description:
-          'The release preview found no blocking conflicts. Choose a version bump to tag the draft snapshot.',
+          'The release preview found no blocking conflicts. Confirm to tag the draft snapshot.',
         choices,
       },
     });
@@ -1790,22 +1820,22 @@ export class ReleaseTrackPageComponent implements OnInit {
     releaseRef
       .afterClosed()
       .pipe(take(1))
-      .subscribe((type: 'major' | 'minor' | undefined) => {
-        if (type !== 'major' && type !== 'minor') return;
-        this.bumpRelease(type, item);
+      .subscribe((action: 'release' | undefined) => {
+        if (action !== 'release') return;
+        this.releaseSnapshot(selection, item);
       });
   }
 
-  private bumpRelease(
-    type: 'major' | 'minor',
+  private releaseSnapshot(
+    selection: ReleasePayload,
     item?: SnapshotHistoryViewModel
   ): void {
     if (!this.id) return;
 
     this.isReleasing = true;
     const release = item?.modified
-      ? this.connector.bumpByModified(this.id, item.modified, { type })
-      : this.connector.bumpByLatest(this.id, { type });
+      ? this.connector.releaseSnapshot(this.id, item.modified, selection)
+      : this.connector.releaseLatest(this.id, selection);
 
     release
       .pipe(
@@ -1827,20 +1857,22 @@ export class ReleaseTrackPageComponent implements OnInit {
   }
 
   private getReleasePreviewDescription(preview: any): string {
-    const included =
-      preview?.statistics?.included_objects ??
-      preview?.release_preview?.will_include?.length ??
-      preview?.staged_count ??
-      0;
-    const excluded =
-      preview?.statistics?.excluded_objects ??
-      preview?.release_preview?.will_exclude?.length ??
-      preview?.candidates_count ??
-      0;
+    if (preview?.type === ReleaseTrackType.Virtual) {
+      const changes = preview?.changes || {};
+      return `${changes.new_count || 0} new, ${
+        changes.updated_count || 0
+      } updated, ${changes.removed_count || 0} removed, and ${
+        changes.quarantined_count || 0
+      } quarantined objects.`;
+    }
 
-    return `${included} object${included === 1 ? '' : 's'} will be included. ${
-      excluded || 0
-    } object${excluded === 1 ? '' : 's'} will remain out of this release.`;
+    const promoted = preview?.changes?.promoted_count || 0;
+    const candidates = preview?.after?.candidates_count || 0;
+    return `${promoted} staged object${
+      promoted === 1 ? '' : 's'
+    } will become members. ${candidates} candidate object${
+      candidates === 1 ? '' : 's'
+    } will remain outside the release.`;
   }
 
   private buildSnapshotHistory(

--- a/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.ts
+++ b/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.ts
@@ -63,20 +63,17 @@ interface ReleaseTrackWorkspaceLane {
   isReleasedMembers?: boolean;
 }
 
-interface SnapshotMemberRef {
-  object_ref: string;
-  object_modified?: string;
-}
-
 interface SnapshotHistoryViewModel {
   snapshot: ReleaseTrackSnapshotHistoryItem;
   title: string;
   created: Date | null;
   modified: string | null;
   isTagged: boolean;
-  addedCount: number;
-  modifiedCount: number;
-  totalObjects: number;
+  isVirtual: boolean;
+  membersCount: number;
+  stagedCount?: number;
+  candidatesCount?: number;
+  quarantineCount?: number;
 }
 
 interface ReleaseTrackConfigFormValue {
@@ -563,8 +560,8 @@ export class ReleaseTrackPageComponent implements OnInit {
         })
       )
       .subscribe({
-        next: snapshots => {
-          this.snapshotHistory = this.buildSnapshotHistory(snapshots);
+        next: result => {
+          this.snapshotHistory = this.buildSnapshotHistory(result.data);
         },
         error: err => {
           console.error('Failed to load release track snapshot history', err);
@@ -1882,36 +1879,31 @@ export class ReleaseTrackPageComponent implements OnInit {
       (a, b) => this.getSnapshotTime(b) - this.getSnapshotTime(a)
     );
 
-    return sorted.map((snapshot, index) => {
-      const previousSnapshot = sorted[index + 1];
-      const currentMembers = this.getSnapshotMembers(snapshot);
-      const previousMembers = previousSnapshot
-        ? this.getSnapshotMembers(previousSnapshot)
-        : [];
-
-      return {
-        snapshot,
-        title: this.getSnapshotTitle(snapshot),
-        created: this.getSnapshotDate(snapshot),
-        modified: this.getSnapshotModified(snapshot),
-        isTagged: this.isTaggedSnapshot(snapshot),
-        addedCount: this.getAddedCount(
-          snapshot,
-          currentMembers,
-          previousMembers
-        ),
-        modifiedCount: this.getModifiedCount(
-          snapshot,
-          currentMembers,
-          previousMembers
-        ),
-        totalObjects: this.getSnapshotTotalObjects(snapshot, currentMembers),
-      };
-    });
+    return sorted.map(snapshot => ({
+      snapshot,
+      title: this.getSnapshotTitle(snapshot),
+      created: this.getSnapshotDate(snapshot),
+      modified: snapshot.modified,
+      isTagged: !!snapshot.version,
+      isVirtual: snapshot.type === ReleaseTrackType.Virtual,
+      membersCount: snapshot.members_count,
+      stagedCount:
+        snapshot.type === ReleaseTrackType.Standard
+          ? snapshot.staged_count
+          : undefined,
+      candidatesCount:
+        snapshot.type === ReleaseTrackType.Standard
+          ? snapshot.candidates_count
+          : undefined,
+      quarantineCount:
+        snapshot.type === ReleaseTrackType.Virtual
+          ? snapshot.quarantine_count
+          : undefined,
+    }));
   }
 
   private getSnapshotTitle(snapshot: ReleaseTrackSnapshotHistoryItem): string {
-    const version = snapshot.version || snapshot.stix?.x_mitre_version;
+    const version = snapshot.version;
     if (!version) return 'Draft Snapshot';
     return String(version).startsWith('v') ? String(version) : `v${version}`;
   }
@@ -1919,137 +1911,11 @@ export class ReleaseTrackPageComponent implements OnInit {
   private getSnapshotDate(
     snapshot: ReleaseTrackSnapshotHistoryItem
   ): Date | null {
-    const value =
-      snapshot.created ||
-      snapshot.modified ||
-      snapshot.snapshot_id ||
-      snapshot.tagged_at ||
-      snapshot.stix?.modified;
-    return value ? new Date(value) : null;
-  }
-
-  private getSnapshotModified(
-    snapshot: ReleaseTrackSnapshotHistoryItem
-  ): string | null {
-    const value =
-      snapshot.modified || snapshot.snapshot_id || snapshot.stix?.modified;
-    if (!value) return null;
-    return value instanceof Date ? value.toISOString() : String(value);
+    return snapshot.modified ? new Date(snapshot.modified) : null;
   }
 
   private getSnapshotTime(snapshot: ReleaseTrackSnapshotHistoryItem): number {
     return this.getSnapshotDate(snapshot)?.getTime() || 0;
-  }
-
-  private isTaggedSnapshot(snapshot: ReleaseTrackSnapshotHistoryItem): boolean {
-    return !!(snapshot.version || snapshot.stix?.x_mitre_version);
-  }
-
-  private getSnapshotMembers(
-    snapshot: ReleaseTrackSnapshotHistoryItem
-  ): SnapshotMemberRef[] {
-    const members =
-      snapshot.members ||
-      snapshot.contents?.members ||
-      snapshot.stix?.x_mitre_contents ||
-      [];
-
-    return members
-      .map((member: any) => this.getSnapshotMemberRef(member))
-      .filter((member): member is SnapshotMemberRef => !!member);
-  }
-
-  private getSnapshotMemberRef(member: any): SnapshotMemberRef | null {
-    if (!member) return null;
-
-    if (typeof member === 'string') {
-      return { object_ref: member };
-    }
-
-    const objectRef =
-      member.object_ref ||
-      member.id ||
-      member.object_id ||
-      member.stixID ||
-      member.stix?.id;
-
-    if (!objectRef) return null;
-
-    const objectModified =
-      member.object_modified || member.modified || member.stix?.modified;
-
-    return {
-      object_ref: objectRef,
-      object_modified: objectModified
-        ? this.toIsoString(objectModified)
-        : undefined,
-    };
-  }
-
-  private getAddedCount(
-    snapshot: ReleaseTrackSnapshotHistoryItem,
-    currentMembers: SnapshotMemberRef[],
-    previousMembers: SnapshotMemberRef[]
-  ): number {
-    if (typeof snapshot.summary?.added_count === 'number') {
-      return snapshot.summary.added_count;
-    }
-    if (typeof snapshot.summary?.promoted_count === 'number') {
-      return snapshot.summary.promoted_count;
-    }
-    if (!previousMembers.length) return 0;
-
-    const previousRefs = new Set(
-      previousMembers.map(member => member.object_ref)
-    );
-    return currentMembers.filter(member => !previousRefs.has(member.object_ref))
-      .length;
-  }
-
-  private getModifiedCount(
-    snapshot: ReleaseTrackSnapshotHistoryItem,
-    currentMembers: SnapshotMemberRef[],
-    previousMembers: SnapshotMemberRef[]
-  ): number {
-    if (typeof snapshot.summary?.modified_count === 'number') {
-      return snapshot.summary.modified_count;
-    }
-    if (!previousMembers.length) return 0;
-
-    const previousByRef = new Map(
-      previousMembers.map(member => [member.object_ref, member.object_modified])
-    );
-
-    return currentMembers.filter(member => {
-      const previousModified = previousByRef.get(member.object_ref);
-      return (
-        !!member.object_modified &&
-        !!previousModified &&
-        member.object_modified !== previousModified
-      );
-    }).length;
-  }
-
-  private getSnapshotTotalObjects(
-    snapshot: ReleaseTrackSnapshotHistoryItem,
-    members: SnapshotMemberRef[]
-  ): number {
-    if (typeof snapshot.summary?.members_count === 'number') {
-      return snapshot.summary.members_count;
-    }
-    if (typeof snapshot.composition_resolution?.total_objects === 'number') {
-      return snapshot.composition_resolution.total_objects;
-    }
-    if (members.length) return members.length;
-
-    const allRefs = [
-      ...(snapshot.candidates || snapshot.contents?.candidates || []),
-      ...(snapshot.staged || snapshot.contents?.staged || []),
-    ]
-      .map(item => this.getSnapshotMemberRef(item)?.object_ref)
-      .filter((ref): ref is string => !!ref);
-
-    return new Set(allRefs).size;
   }
 
   private getSnapshotExportFilename(

--- a/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.ts
+++ b/src/app/views/dashboard-page/release-management/release-track-page/release-track-page.component.ts
@@ -1243,67 +1243,16 @@ export class ReleaseTrackPageComponent implements OnInit {
     return `${safeName}-latest-${format}.json`;
   }
 
-  private getVirtualSnapshotPreviewDescription(preview: any): string {
-    const resolved =
-      preview?.preview?.would_resolve_to ||
-      preview?.would_resolve_to ||
-      preview?.composition_resolution ||
-      preview;
-    const components = resolved?.component_snapshots || [];
-    const totalObjects =
-      resolved?.total_objects ||
-      resolved?.summary?.total_objects ||
-      preview?.total_objects ||
-      preview?.summary?.total_objects;
-
-    const componentText = components.length
-      ? `Components: ${components
-          .map((component: any) => {
-            const name =
-              component.track_name || component.track_id || 'component track';
-            const version =
-              component.resolved_version ||
-              component.version ||
-              component.resolved_snapshot;
-            return version ? `${name} (${version})` : name;
-          })
-          .join(', ')}.`
-      : 'No component details were returned.';
-    const objectText =
-      totalObjects === undefined || totalObjects === null
-        ? 'Object count was not returned.'
-        : `${totalObjects} objects will be resolved.`;
-
-    return `${objectText} ${componentText}`;
-  }
-
   public onDraft(): void {
     if (!this.canCreateDraft) return;
 
-    this.isCreatingDraft = true;
-    this.connector
-      .previewVirtualSnapshot(this.id)
-      .pipe(take(1))
-      .subscribe({
-        next: preview => {
-          this.isCreatingDraft = false;
-          if (!preview) return;
-          this.openVirtualSnapshotPreview(preview);
-        },
-        error: err => {
-          this.isCreatingDraft = false;
-          console.error('Failed to preview draft snapshot', err);
-        },
-      });
-  }
-
-  private openVirtualSnapshotPreview(preview: any): void {
     const dialogRef = this.dialog.open(MultipleChoiceDialogComponent, {
       width: '30em',
       autoFocus: false,
       data: {
         title: 'Create draft snapshot?',
-        description: this.getVirtualSnapshotPreviewDescription(preview),
+        description:
+          'Resolve the tagged component releases into a persistent virtual draft snapshot.',
         choices: [
           {
             label: 'Create Draft',


### PR DESCRIPTION
### Changes
- replaced the old "bump" terminology with "release"
- renamed corresponding connector methods + tests
- updated release operations to use:
  ```
  GET  /api/release-tracks/:id/snapshots/latest/release/preview
  POST /api/release-tracks/:id/snapshots/latest/release
  
  GET  /api/release-tracks/:id/snapshots/:modified/release/preview
  POST /api/release-tracks/:id/snapshots/:modified/release
  ```
- release previews now use `GET` query parameters
- release commits use a req body containing either `increment: "major" | "minor"` or `version: "X.Y"` (or neither, which defaults to a minor release)
- virtual-only track operations now use an explicit `/virtual/` namespace:
  ```
  PUT  /api/release-tracks/:id/virtual/composition
  POST /api/release-tracks/:id/virtual/snapshots/create
  POST /api/release-tracks/:id/virtual/quarantine/promote
  ```
- removed the old virtual snapshot preview endpoint. creating a virtual snapshot (draft) now calls the `/create` endpoint directly.
- integration tests now use the explicit latest-snapshot route: `GET /api/release-tracks/:id/snapshots/latest`
- snapshot history now consumes the server's paginated response:
  ```json
  {
    "data": [],
    "pagination": {
      "total": 0,
      "limit": 50,
      "offset": 0,
    }
  }
  ```
- snapshot history entries are treated as lightweight summaries, not full snapshots
- history cards now display authoritative, type specific counts
  - standard tracks: show counts for `members`, `staged`, and `candidates`
  - virtual tracks: shows counts for `members` and `quarantine`
- removed incorrect calculations that attempted to infer added or modified objects from arrays that are never returned 
- added rest-api-connector support for `tagged`, `limit`, `and `offset` params
- the rest-api-connector now supplies the required `confirm_track_id` parameter for destructive operations:
  - `DELETE /api/release-tracks/:id` (deletes an entire release track)
  - `POST /api/release-tracks/:id/contents` (updates `members` in already-existing latest snapshot)
  - `POST /api/release-tracks/:id/snapshots/:modified/contents` (updates `members` in already-existing non-latest snapshot)